### PR TITLE
refactor: migrate remaining components to Base UI primitives (#39)

### DIFF
--- a/src/components/chat/SuggestedActions.tsx
+++ b/src/components/chat/SuggestedActions.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { addOpacity } from '../../utils/format';
+import { Button } from '../base/Button';
 
 interface SuggestedAction {
   id: string;
@@ -31,8 +32,10 @@ export const SuggestedActions: React.FC<SuggestedActionsProps> = ({
   return (
     <div className='mt-2.5 mb-1.5 p-0 flex flex-col gap-1'>
       {actions.map((action, chipIndex) => (
-        <button
+        <Button
           key={`welcome-chip-${action.id}-${chipIndex}`}
+          variant='ghost'
+          size='sm'
           onClick={e => onActionClick(action, e)}
           disabled={hasPendingMessage}
           className={`
@@ -70,7 +73,7 @@ export const SuggestedActions: React.FC<SuggestedActionsProps> = ({
               action.text
             )}
           </span>
-        </button>
+        </Button>
       ))}
     </div>
   );

--- a/src/components/ui/DiagnosticModal.tsx
+++ b/src/components/ui/DiagnosticModal.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { FiX } from 'react-icons/fi';
 
-import { LAYER_TOKENS } from '../../design-system/layers';
 import { Button } from '../base/Button';
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '../base/Dialog';
 
 interface DiagnosticModalProps {
   isOpen: boolean;
@@ -19,8 +19,6 @@ interface DiagnosticModalProps {
 }
 
 export const DiagnosticModal: React.FC<DiagnosticModalProps> = ({ isOpen, onClose, diagnosticData }) => {
-  if (!isOpen) return null;
-
   const copyToClipboard = (text: string | null | undefined) => {
     if (!text) return;
     navigator.clipboard.writeText(text.toString());
@@ -43,28 +41,25 @@ export const DiagnosticModal: React.FC<DiagnosticModalProps> = ({ isOpen, onClos
   ];
 
   return (
-    <div
-      className='fixed inset-0 flex items-center justify-center'
-      style={{ zIndex: LAYER_TOKENS.modal + 10 }}
-      onClick={onClose}
+    <Dialog
+      open={isOpen}
+      onOpenChange={open => {
+        if (!open) onClose();
+      }}
     >
-      <div className='bg-white rounded-md shadow-lg border border-gray-200 w-64' onClick={e => e.stopPropagation()}>
+      <DialogContent className='bg-white rounded-md shadow-lg border border-gray-200 w-64 p-0'>
         {/* Header */}
         <div className='flex items-center justify-between px-3 py-1.5 border-b border-gray-100'>
-          <span className='text-[11px] font-semibold text-gray-700 flex-1 text-center'>
+          <DialogTitle className='text-[11px] font-semibold text-gray-700 flex-1 text-center mb-0'>
             Widget v{diagnosticData.version} (
             {diagnosticData.build === 'dev' ? 'dev' : diagnosticData.build.slice(0, 7)})
-          </span>
-          <Button
-            type='button'
-            variant='ghost'
-            size='sm'
-            onClick={onClose}
-            className='text-gray-400 hover:text-gray-600 -mr-1 min-w-0 p-0'
+          </DialogTitle>
+          <DialogClose
+            className='text-gray-400 hover:text-gray-600 -mr-1 static w-auto h-auto'
             aria-label='Close diagnostic'
           >
             <FiX className='w-3 h-3' />
-          </Button>
+          </DialogClose>
         </div>
 
         {/* Content */}
@@ -99,7 +94,7 @@ export const DiagnosticModal: React.FC<DiagnosticModalProps> = ({ isOpen, onClos
             </span>
           </div>
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/src/components/ui/ScreenAccessModal.tsx
+++ b/src/components/ui/ScreenAccessModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { Button } from '../base/Button';
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '../base/Dialog';
 
 interface ScreenAccessModalProps {
   isOpen: boolean;
@@ -10,56 +11,52 @@ interface ScreenAccessModalProps {
 }
 
 export const ScreenAccessModal: React.FC<ScreenAccessModalProps> = ({ isOpen, onAllow, onDeny, onClose }) => {
-  if (!isOpen) return null;
-
   return (
-    <div
-      className='absolute inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 rounded-lg'
-      onClick={e => {
-        if (e.target === e.currentTarget) {
-          onClose();
-        }
+    <Dialog
+      open={isOpen}
+      onOpenChange={open => {
+        if (!open) onClose();
       }}
     >
-      <div className='bg-white rounded-lg p-3 max-w-md mx-4 shadow-xl' onClick={e => e.stopPropagation()}>
-        <div className='text-center'>
-          <h3 className='text-lg font-semibold text-gray-900 mb-3'>Can I take a look at your screen?</h3>
-          <p className='text-gray-600 mb-6 text-sm leading-relaxed'>
-            By allowing screen access, Marketrix can understand your current context to guide you better and complete
-            tasks on your behalf.
-          </p>
-          <div className='flex gap-3 justify-center'>
-            <Button
-              type='button'
-              variant='primary'
-              size='sm'
-              onClick={e => {
-                e.preventDefault();
-                e.stopPropagation();
-                onAllow();
-              }}
-              className='px-5 py-1 rounded-full text-sm font-medium'
-              style={{ backgroundColor: '#111827', color: '#fff', border: 'none' }}
-            >
-              Yes
-            </Button>
-            <Button
-              type='button'
-              variant='secondary'
-              size='sm'
-              onClick={e => {
-                e.preventDefault();
-                e.stopPropagation();
-                onDeny();
-              }}
-              className='px-6 py-1 rounded-full text-sm font-medium border border-gray-200'
-              style={{ backgroundColor: '#f3f4f6', color: '#1f2937' }}
-            >
-              No
-            </Button>
-          </div>
+      <DialogContent className='bg-white rounded-lg p-3 max-w-md mx-4 shadow-xl text-center'>
+        <DialogTitle className='text-lg font-semibold text-gray-900 mb-3'>
+          Can I take a look at your screen?
+        </DialogTitle>
+        <DialogDescription className='text-gray-600 mb-6 text-sm leading-relaxed'>
+          By allowing screen access, Marketrix can understand your current context to guide you better and complete
+          tasks on your behalf.
+        </DialogDescription>
+        <div className='flex gap-3 justify-center'>
+          <Button
+            type='button'
+            variant='primary'
+            size='sm'
+            onClick={e => {
+              e.preventDefault();
+              e.stopPropagation();
+              onAllow();
+            }}
+            className='px-5 py-1 rounded-full text-sm font-medium'
+            style={{ backgroundColor: '#111827', color: '#fff', border: 'none' }}
+          >
+            Yes
+          </Button>
+          <Button
+            type='button'
+            variant='secondary'
+            size='sm'
+            onClick={e => {
+              e.preventDefault();
+              e.stopPropagation();
+              onDeny();
+            }}
+            className='px-6 py-1 rounded-full text-sm font-medium border border-gray-200'
+            style={{ backgroundColor: '#f3f4f6', color: '#1f2937' }}
+          >
+            No
+          </Button>
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 };


### PR DESCRIPTION
Closes #39

- SuggestedActions: raw `<button>` → `base/Button` (ghost, sm)
- ScreenAccessModal: custom overlay → `base/Dialog`
- DiagnosticModal: custom modal → `base/Dialog`

MessageInput and ModeSelector were already migrated in PR #41.