### PR TITLE
fix: widget layout — chip radius, close button, fonts, back chevron (#48)

### DIFF
--- a/src/components/chat/SuggestedActions.tsx
+++ b/src/components/chat/SuggestedActions.tsx
@@ -39,7 +39,7 @@ export const SuggestedActions: React.FC<SuggestedActionsProps> = ({
           onClick={e => onActionClick(action, e)}
           disabled={hasPendingMessage}
           className={`
-            w-full flex items-center justify-center gap-1 font-inter font-normal text-xs px-3 py-2 rounded-full
+            w-full flex items-center justify-center gap-1 font-inter font-normal text-xs px-3 py-2 rounded-xl
             transition-[background-color,color,border-color] duration-[250ms] ease-in-out text-left
             border border-solid
             ${hasPendingMessage ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}

--- a/src/components/navigation/MessengerShell.tsx
+++ b/src/components/navigation/MessengerShell.tsx
@@ -232,6 +232,7 @@ export const MessengerShell: React.FC<MessengerShellProps> = ({
                     messages={messages}
                     onNavigateToChat={handleNavigateToChat}
                     onChipClick={handleChipClick}
+                    onClose={onClose}
                   />
                 )}
                 {activeView === 'chat' && (
@@ -249,10 +250,6 @@ export const MessengerShell: React.FC<MessengerShellProps> = ({
                     onStopTask={onStopTask}
                     onClearChat={onClearChat}
                     onClose={onClose}
-                    onBack={() => {
-                      setNavDirection('back');
-                      setActiveView('home');
-                    }}
                     onScreenSharingChange={onScreenSharingChange}
                     messageInputRef={messageInputRef}
                   />

--- a/src/components/views/ChatView.tsx
+++ b/src/components/views/ChatView.tsx
@@ -69,7 +69,6 @@ export interface ChatViewProps {
   onStopTask?: () => void;
   onClearChat?: () => void | Promise<void>;
   onClose: () => void;
-  onBack: () => void;
   onScreenSharingChange?: (isSharing: boolean) => void;
   /** Optional ref for focus trap to focus the message input */
   messageInputRef?: React.RefObject<HTMLTextAreaElement | null>;
@@ -103,7 +102,6 @@ export const ChatView: React.FC<ChatViewProps> = ({
   onStopTask,
   onClearChat,
   onClose,
-  onBack,
   onScreenSharingChange,
   messageInputRef: externalMessageInputRef,
 }) => {
@@ -335,19 +333,6 @@ export const ChatView: React.FC<ChatViewProps> = ({
         }}
       >
         <div className='flex items-center gap-2 min-w-0 flex-1'>
-          <Button
-            type='button'
-            variant='ghost'
-            size='sm'
-            onClick={onBack}
-            className='p-1.5 rounded-full opacity-60 hover:opacity-100 transition-opacity -ml-0.5'
-            style={{ color: config.widget_text_color }}
-            aria-label='Back to home'
-          >
-            <svg className='w-4 h-4' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-              <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M15 19l-7-7 7-7' />
-            </svg>
-          </Button>
           <img
             src={MarketrixIcon}
             alt=''

--- a/src/components/views/HomeView.tsx
+++ b/src/components/views/HomeView.tsx
@@ -11,9 +11,10 @@ interface HomeViewProps {
   messages: ChatMessage[];
   onNavigateToChat: () => void;
   onChipClick: (action: SuggestedActionItem) => void;
+  onClose: () => void;
 }
 
-export const HomeView: React.FC<HomeViewProps> = ({ config, messages, onNavigateToChat, onChipClick }) => {
+export const HomeView: React.FC<HomeViewProps> = ({ config, messages, onNavigateToChat, onChipClick, onClose }) => {
   const suggestedActions = getSuggestedActionsFromConfig(config);
   const accentColor = config.widget_accent_color ?? '#3b82f6';
   const textColor = config.widget_text_color ?? '#1f2937';
@@ -27,27 +28,45 @@ export const HomeView: React.FC<HomeViewProps> = ({ config, messages, onNavigate
 
   return (
     <div className='flex flex-col h-full overflow-hidden' id='view-home' role='tabpanel' aria-labelledby='tab-home'>
-      <div className='flex-1 overflow-y-auto p-3 space-y-3'>
-        {/* Hero / greeting */}
-        <div className='flex flex-col gap-1'>
-          <div className='flex items-center gap-2'>
-            <img
-              src={MarketrixIcon}
-              alt=''
-              className='w-10 h-10 rounded-[var(--radius)] object-cover flex-shrink-0'
-              style={{ boxShadow: config.widget_shadow }}
-            />
-            <div>
-              <h2 className='text-base font-semibold leading-tight' style={{ color: textColor }}>
-                {config.widget_greeting ?? 'Hello'}
-              </h2>
-              <p className='text-sm opacity-80' style={{ color: textColor }}>
-                {config.widget_body ?? 'How can we help?'}
-              </p>
+      {/* Header with close button */}
+      <div
+        className='flex justify-between items-center px-3 py-2 border-b flex-shrink-0'
+        style={{ borderColor: config.widget_border_color }}
+      >
+        <div className='flex items-center gap-2 min-w-0 flex-1'>
+          <img
+            src={MarketrixIcon}
+            alt=''
+            className='flex-shrink-0 w-8 h-8 rounded-[var(--radius)] object-cover'
+            style={{ boxShadow: config.widget_shadow }}
+          />
+          <div className='min-w-0'>
+            <div className='text-sm font-semibold leading-tight truncate' style={{ color: textColor }}>
+              {config.widget_greeting ?? 'Hello'}
             </div>
+            <p className='text-xs opacity-70 truncate' style={{ color: textColor }}>
+              {config.widget_body ?? 'How can we help?'}
+            </p>
           </div>
         </div>
+        <button
+          type='button'
+          onClick={onClose}
+          className='p-1.5 rounded-full opacity-60 hover:opacity-100 transition-opacity flex-shrink-0'
+          style={{ color: textColor }}
+          aria-label='Close'
+        >
+          <svg className='w-4 h-4' fill='currentColor' viewBox='0 0 20 20'>
+            <path
+              fillRule='evenodd'
+              d='M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z'
+              clipRule='evenodd'
+            />
+          </svg>
+        </button>
+      </div>
 
+      <div className='flex-1 overflow-y-auto p-3 space-y-3'>
         {/* Ask a question CTA */}
         <button
           type='button'


### PR DESCRIPTION
Closes #48

- Chip border-radius: `rounded-full` → `rounded-xl` (fixed 12px, consistent regardless of content)
- Home view: added close button header matching Chat view
- Font sizes: standardized headings across views
- Chat view: removed redundant back chevron (tabs handle navigation)