### PR TITLE
refactor: widget layout overhaul — header, input, chips, welcome message

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -4,10 +4,8 @@ import { FaArrowDown, FaArrowUp } from 'react-icons/fa';
 
 import MarketrixIcon from '../../assets/marketrix-icon.svg';
 import { useWidget } from '../../hooks/useWidget';
-import { createUserMessage } from '../../services/ChatService';
 import type { ChatMessage, MarketrixConfig } from '../../types';
 import { addOpacity } from '../../utils/format';
-import { getSuggestedActionsFromConfig } from '../../utils/suggestedActions';
 import { Button } from '../base/Button';
 import { StateMessage } from '../ui/StateMessage';
 import { MessageItem } from './MessageItem';
@@ -28,10 +26,10 @@ interface MessageListProps {
 export const MessageList = ({
   messages,
   messagesEndRef,
-  onSendMessage,
-  onSetMode,
-  onModeChange,
-  onAddMessage,
+  onSendMessage: _onSendMessage,
+  onSetMode: _onSetMode,
+  onModeChange: _onModeChange,
+  onAddMessage: _onAddMessage,
   config,
   onScreenAccessAllow,
   onScreenAccessDeny,
@@ -80,55 +78,6 @@ export const MessageList = ({
     });
   }, [messages.length, isPreviewMode]); // Run when messages length changes to handle history loading
 
-  // Check if there's a pending message (placeholder exists or isLoading)
-  const hasPendingMessage = widgetState.isLoading || messages.some(msg => msg.isPlaceholder);
-
-  const suggestedActions = getSuggestedActionsFromConfig(widgetConfig);
-  const uniqueSuggestedActions = suggestedActions;
-
-  const handleSuggestedActionClick = async (action: (typeof suggestedActions)[0], event: React.MouseEvent) => {
-    event.preventDefault();
-    event.stopPropagation();
-
-    // Don't allow clicking chips when there's a pending message
-    if (hasPendingMessage) {
-      return;
-    }
-
-    // FIRST: Switch to the chip's mode if not already in that mode
-    // Use onModeChange if available (adds system message), otherwise fall back to onSetMode
-    if (action.type) {
-      if (onModeChange) {
-        // onModeChange adds system message and switches mode
-        console.log('Changing mode to:', action.type);
-        onModeChange(action.type);
-      } else if (onSetMode) {
-        // Fallback to direct mode set
-        console.log('Setting mode to:', action.type);
-        onSetMode(action.type);
-      }
-
-      // Wait a tick to ensure mode change is processed and UI updates
-      await new Promise(resolve => setTimeout(resolve, 0));
-    }
-
-    // THEN: Add the chip message as a user message in the chat (like user typed it)
-    // The greeting message and all existing messages remain unchanged
-    if (onAddMessage) {
-      // We import createUserMessage from ChatService now (exported function)
-      const userMessage = createUserMessage(action.text, action.type, 'chip-message');
-      onAddMessage(userMessage);
-    }
-
-    // Send message through normal flow (will check for screen access if needed)
-    // This ensures chips get the same treatment as typing a message
-    if (onSendMessage) {
-      console.log('Sending message with mode:', action.type, action.text);
-      // The wrapper in ChatWindow will handle screen access check
-      onSendMessage(action.text, action.type);
-    }
-  };
-
   return (
     <div className='relative h-full'>
       <div
@@ -163,9 +112,6 @@ export const MessageList = ({
             widget_secondary_color: widgetConfig.widget_secondary_color,
           }}
           marketrixIcon={MarketrixIcon}
-          suggestedActions={uniqueSuggestedActions}
-          hasPendingMessage={hasPendingMessage}
-          onActionClick={handleSuggestedActionClick}
         />
 
         {/* Messages */}

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -103,7 +103,7 @@ export const MessageList = ({
 
         {/* Welcome message - always show */}
         <WelcomeMessage
-          greeting={widgetConfig.widget_greeting}
+          greeting={widgetConfig.widget_body ?? 'How can I help you today?'}
           settings={{
             widget_shadow: widgetConfig.widget_shadow,
             widget_border_radius: widgetConfig.widget_border_radius,
@@ -111,7 +111,6 @@ export const MessageList = ({
             widget_border_color: widgetConfig.widget_border_color,
             widget_secondary_color: widgetConfig.widget_secondary_color,
           }}
-          marketrixIcon={MarketrixIcon}
         />
 
         {/* Messages */}

--- a/src/components/chat/WelcomeMessage.tsx
+++ b/src/components/chat/WelcomeMessage.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { formatMessageTime } from '../../utils/format';
-import { SuggestedActions } from './SuggestedActions';
 
 interface WelcomeMessageProps {
   greeting: string;
@@ -13,34 +12,9 @@ interface WelcomeMessageProps {
     widget_secondary_color: string;
   };
   marketrixIcon: string;
-  suggestedActions: Array<{
-    id: string;
-    text: string;
-    icon: React.ReactElement;
-    type: 'tell' | 'show' | 'do';
-    isShow: boolean;
-  }>;
-  hasPendingMessage: boolean;
-  onActionClick: (
-    action: {
-      id: string;
-      text: string;
-      icon: React.ReactElement;
-      type: 'tell' | 'show' | 'do';
-      isShow: boolean;
-    },
-    event: React.MouseEvent,
-  ) => Promise<void>;
 }
 
-export const WelcomeMessage: React.FC<WelcomeMessageProps> = ({
-  greeting,
-  settings,
-  marketrixIcon,
-  suggestedActions,
-  hasPendingMessage,
-  onActionClick,
-}) => {
+export const WelcomeMessage: React.FC<WelcomeMessageProps> = ({ greeting, settings, marketrixIcon }) => {
   return (
     <div key='welcome-message' className='group flex flex-col justify-start mt-2'>
       <style>{`
@@ -98,16 +72,6 @@ export const WelcomeMessage: React.FC<WelcomeMessageProps> = ({
         >
           {/* Message content */}
           <div className='text-xs font-inter font-medium leading-tight whitespace-pre-wrap break-words'>{greeting}</div>
-
-          {/* Chips inside the greeting message bubble */}
-          {suggestedActions.length > 0 && (
-            <SuggestedActions
-              actions={suggestedActions}
-              hasPendingMessage={hasPendingMessage}
-              settings={settings}
-              onActionClick={onActionClick}
-            />
-          )}
         </div>
       </div>
       {/* Timestamp below card - agent message, so right-aligned */}

--- a/src/components/chat/WelcomeMessage.tsx
+++ b/src/components/chat/WelcomeMessage.tsx
@@ -11,57 +11,17 @@ interface WelcomeMessageProps {
     widget_border_color: string;
     widget_secondary_color: string;
   };
-  marketrixIcon: string;
 }
 
-export const WelcomeMessage: React.FC<WelcomeMessageProps> = ({ greeting, settings, marketrixIcon }) => {
+export const WelcomeMessage: React.FC<WelcomeMessageProps> = ({ greeting, settings }) => {
   return (
     <div key='welcome-message' className='group flex flex-col justify-start mt-2'>
-      <style>{`
-        .agent-logo-img {
-          border: none !important;
-          outline: none !important;
-          box-shadow: ${settings.widget_shadow} !important;
-          background-color: transparent !important;
-          border-radius: ${settings.widget_border_radius} !important;
-        }
-        .agent-logo-img-container {
-          background-color: transparent !important;
-        }
-      `}</style>
-      <div className='flex items-start gap-1 flex-row'>
-        {/* Agent Logo */}
-        <div
-          className='flex-shrink-0 agent-logo-img-container'
-          style={{
-            backgroundColor: 'transparent',
-            width: '32px',
-            height: '32px',
-          }}
-        >
-          <img
-            src={marketrixIcon}
-            alt='Marketrix AI'
-            className='agent-logo-img'
-            style={{
-              width: '32px',
-              height: '32px',
-              boxShadow: settings.widget_shadow,
-              borderRadius: settings.widget_border_radius,
-              border: 'none',
-              outline: 'none',
-              display: 'block',
-              objectFit: 'cover',
-              backgroundColor: 'transparent',
-            }}
-          />
-        </div>
-
+      <div className='flex items-start flex-row'>
         {/* Message bubble */}
         <div
           className={`
             flex flex-col flex-1
-            px-2.5 py-2 rounded-r-lg rounded-tl-lg rounded-bl-lg shadow-sm border
+            px-2.5 py-2 rounded-lg shadow-sm border
           `}
           style={{
             backgroundColor: '#ffffff',
@@ -74,7 +34,7 @@ export const WelcomeMessage: React.FC<WelcomeMessageProps> = ({ greeting, settin
           <div className='text-xs font-inter font-medium leading-tight whitespace-pre-wrap break-words'>{greeting}</div>
         </div>
       </div>
-      {/* Timestamp below card - agent message, so right-aligned */}
+      {/* Timestamp below card */}
       <div className='flex justify-end mt-0.5'>
         <span className='text-[10px] font-inter font-normal' style={{ color: `${settings.widget_text_color}99` }}>
           {formatMessageTime(new Date())}

--- a/src/components/input/MessageInput.tsx
+++ b/src/components/input/MessageInput.tsx
@@ -1,9 +1,12 @@
 import React, { useCallback, useEffect, useRef } from 'react';
-import { IoSend, IoStop } from 'react-icons/io5';
+import { IoChatbubbleEllipsesOutline, IoStop } from 'react-icons/io5';
+import { LuMousePointerClick } from 'react-icons/lu';
+import { SiTicktick } from 'react-icons/si';
 
 import { useWidget } from '../../hooks/useWidget';
+import type { InstructionType } from '../../sdk';
 import type { MarketrixConfig } from '../../types';
-import { addOpacity, getContrastingColor } from '../../utils/format';
+import { addOpacity, getContrastingColor, getModeDisplayName } from '../../utils/format';
 import { Button } from '../base/Button';
 import { Textarea } from '../base/Textarea';
 
@@ -16,6 +19,10 @@ interface MessageInputProps {
   isTaskRunning?: boolean;
   onStop?: () => void;
   config?: MarketrixConfig;
+  currentMode?: InstructionType;
+  enabledModes?: InstructionType[];
+  onModeChange?: (mode: InstructionType) => void;
+  isScreenSharing?: boolean;
 }
 
 function mergeRefs<T>(...refs: (React.Ref<T> | undefined)[]) {
@@ -28,7 +35,20 @@ function mergeRefs<T>(...refs: (React.Ref<T> | undefined)[]) {
 }
 
 export const MessageInput = React.forwardRef<HTMLTextAreaElement, Omit<MessageInputProps, 'ref'>>(function MessageInput(
-  { value, onChange, onKeyPress, onSend, isLoading, isTaskRunning = false, onStop, config },
+  {
+    value,
+    onChange,
+    onKeyPress,
+    onSend,
+    isLoading,
+    isTaskRunning = false,
+    onStop,
+    config,
+    currentMode,
+    enabledModes = [],
+    onModeChange,
+    isScreenSharing = false,
+  },
   ref,
 ) {
   // Get configuration
@@ -71,116 +91,145 @@ export const MessageInput = React.forwardRef<HTMLTextAreaElement, Omit<MessageIn
 
   const placeholderColor = addOpacity(settings.widget_text_color, 0.6);
   const canSend = Boolean(value.trim()) && !isLoading;
-  const iconBtnStyle = { color: settings.widget_text_color };
+
+  const orderedModes: InstructionType[] = (['tell', 'show', 'do'] as const).filter(m => enabledModes.includes(m));
+
+  const getModeIcon = (mode: InstructionType) => {
+    switch (mode) {
+      case 'show':
+        return <LuMousePointerClick className='w-3 h-3' />;
+      case 'tell':
+        return <IoChatbubbleEllipsesOutline className='w-3 h-3' />;
+      case 'do':
+        return <SiTicktick className='w-3 h-3' />;
+      default:
+        return null;
+    }
+  };
 
   return (
-    <div className='py-1.5 pr-2 bg-transparent'>
+    <div className='py-1.5 px-2 bg-transparent'>
       <style>{`.message-input-textarea::placeholder { color: ${placeholderColor}; }`}</style>
-      <div className='flex items-end gap-2'>
-        <div className='flex-1 relative flex flex-col gap-1'>
-          <Textarea
-            ref={mergeRefs(textareaRef, ref)}
-            value={value}
-            onChange={handleChange}
-            onKeyDown={handleKeyDown as React.KeyboardEventHandler<HTMLTextAreaElement>}
-            placeholder='Ask anything'
-            disabled={isLoading}
-            rows={1}
-            className='message-input-textarea w-full px-3 text-sm resize-none focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed border rounded-none overflow-hidden'
-            style={{
-              backgroundColor: 'rgba(255,255,255,0.7)',
-              backdropFilter: 'blur(10px)',
-              WebkitBackdropFilter: 'blur(10px)',
-              borderColor: settings.widget_border_color,
-              color: settings.widget_text_color,
-              lineHeight: '20px',
-              paddingTop: '6px',
-              paddingBottom: '6px',
-            }}
-          />
-          {/* Composer toolbar: attachment, emoji (placeholders), gap */}
-          <div className='flex items-center gap-1 opacity-60 hover:[&_button:not(:disabled)]:opacity-100 transition-opacity'>
-            <button
+      <div
+        className='flex flex-col rounded-xl border overflow-hidden'
+        style={{
+          borderColor: settings.widget_border_color,
+          backgroundColor: 'rgba(255,255,255,0.7)',
+          backdropFilter: 'blur(10px)',
+          WebkitBackdropFilter: 'blur(10px)',
+        }}
+      >
+        <Textarea
+          ref={mergeRefs(textareaRef, ref)}
+          value={value}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown as React.KeyboardEventHandler<HTMLTextAreaElement>}
+          placeholder='Ask anything'
+          disabled={isLoading}
+          rows={1}
+          className='message-input-textarea w-full px-3 text-sm resize-none focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed border-none overflow-hidden'
+          style={{
+            backgroundColor: 'transparent',
+            color: settings.widget_text_color,
+            lineHeight: '20px',
+            paddingTop: '8px',
+            paddingBottom: '4px',
+          }}
+        />
+        {/* Mode pills + send button row */}
+        <div className='flex items-center justify-between px-1.5 pb-1.5'>
+          <div className='flex items-center gap-1'>
+            {orderedModes.map(mode => {
+              const isActive = currentMode === mode;
+              return (
+                <button
+                  key={mode}
+                  type='button'
+                  onClick={e => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onModeChange?.(mode);
+                  }}
+                  className={`flex items-center gap-0.5 text-[11px] font-medium px-2 py-0.5 transition-all duration-200 ${isActive ? 'shadow-sm' : ''}`}
+                  style={{
+                    borderRadius: '20px',
+                    ...(isActive
+                      ? {
+                          backgroundColor: settings.widget_accent_color,
+                          color: getContrastingColor(settings.widget_accent_color),
+                          border: 'none',
+                        }
+                      : {
+                          backgroundColor: addOpacity(settings.widget_secondary_color, 0.15),
+                          color: addOpacity(settings.widget_text_color, 0.7),
+                          border: 'none',
+                        }),
+                    ...(isScreenSharing && isActive
+                      ? {
+                          animation: 'glow-border-pulse 2s ease-in-out infinite',
+                        }
+                      : {}),
+                  }}
+                >
+                  {getModeIcon(mode)}
+                  <span>{getModeDisplayName(mode)}</span>
+                </button>
+              );
+            })}
+          </div>
+          {isTaskRunning && onStop ? (
+            <Button
               type='button'
-              disabled
-              className='w-4 h-4 p-0 rounded flex items-center justify-center cursor-not-allowed'
-              style={iconBtnStyle}
-              title='Coming soon'
-              aria-label='Attach file (coming soon)'
+              variant='secondary'
+              size='sm'
+              onClick={e => {
+                e.preventDefault();
+                e.stopPropagation();
+                onStop();
+              }}
+              className='w-7 h-7 min-w-7 rounded-full flex items-center justify-center flex-shrink-0 shadow-lg'
+              style={{
+                background: 'linear-gradient(to right, #1f2937, #111827)',
+                color: '#fff',
+                border: 'none',
+              }}
+              aria-label='Stop task'
+            >
+              <IoStop className='w-3.5 h-3.5' />
+            </Button>
+          ) : (
+            <Button
+              type='button'
+              variant='primary'
+              size='sm'
+              disabled={!canSend}
+              onClick={e => {
+                e.preventDefault();
+                e.stopPropagation();
+                onSend();
+              }}
+              className='w-7 h-7 min-w-7 rounded-full flex items-center justify-center flex-shrink-0'
+              style={
+                canSend
+                  ? {
+                      backgroundColor: settings.widget_accent_color,
+                      color: getContrastingColor(settings.widget_accent_color),
+                      border: 'none',
+                    }
+                  : {
+                      backgroundColor: 'transparent',
+                      color: addOpacity(settings.widget_text_color, 0.4),
+                      border: 'none',
+                    }
+              }
+              aria-label='Send message'
             >
               <svg className='w-4 h-4' fill='none' stroke='currentColor' viewBox='0 0 24 24' aria-hidden>
-                <path
-                  strokeLinecap='round'
-                  strokeLinejoin='round'
-                  strokeWidth={2}
-                  d='M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13'
-                />
+                <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M5 10l7-7m0 0l7 7m-7-7v18' />
               </svg>
-            </button>
-            <button
-              type='button'
-              disabled
-              className='w-4 h-4 p-0 rounded flex items-center justify-center cursor-not-allowed'
-              style={iconBtnStyle}
-              title='Coming soon'
-              aria-label='Insert emoji (coming soon)'
-            >
-              <span className='text-base leading-none' aria-hidden>
-                😊
-              </span>
-            </button>
-          </div>
+            </Button>
+          )}
         </div>
-        {isTaskRunning && onStop ? (
-          <Button
-            type='button'
-            variant='secondary'
-            size='sm'
-            onClick={e => {
-              e.preventDefault();
-              e.stopPropagation();
-              onStop();
-            }}
-            className='w-8 h-8 min-w-8 rounded-full flex items-center justify-center flex-shrink-0 shadow-lg'
-            style={{
-              background: 'linear-gradient(to right, #1f2937, #111827)',
-              color: '#fff',
-              border: 'none',
-            }}
-            aria-label='Stop task'
-          >
-            <IoStop className='w-4 h-4' />
-          </Button>
-        ) : (
-          <Button
-            type='button'
-            variant='primary'
-            size='sm'
-            disabled={!canSend}
-            onClick={e => {
-              e.preventDefault();
-              e.stopPropagation();
-              onSend();
-            }}
-            className='w-8 h-8 min-w-8 rounded-full flex items-center justify-center flex-shrink-0'
-            style={
-              canSend
-                ? {
-                    backgroundColor: settings.widget_accent_color,
-                    color: getContrastingColor(settings.widget_accent_color),
-                    border: 'none',
-                  }
-                : {
-                    backgroundColor: 'transparent',
-                    color: addOpacity(settings.widget_text_color, 0.4),
-                    border: 'none',
-                  }
-            }
-            aria-label='Send message'
-          >
-            <IoSend className={canSend ? 'w-4 h-4' : 'w-4 h-4 ml-0.5'} />
-          </Button>
-        )}
       </div>
     </div>
   );

--- a/src/components/navigation/MessengerShell.tsx
+++ b/src/components/navigation/MessengerShell.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 
+import MarketrixIcon from '../../assets/marketrix-icon.svg';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
 import { type ResizeCorner, useResize } from '../../hooks/useResize';
 import { useWidget } from '../../hooks/useWidget';
@@ -224,6 +225,47 @@ export const MessengerShell: React.FC<MessengerShellProps> = ({
           </div>
         ) : (
           <>
+            {/* Shared header: agent name + description */}
+            <div
+              className='flex justify-between items-center px-3 py-2 border-b flex-shrink-0'
+              style={{ borderColor: settings.widget_border_color }}
+            >
+              <div className='flex items-center gap-2 min-w-0 flex-1'>
+                <img
+                  src={MarketrixIcon}
+                  alt=''
+                  className='flex-shrink-0 w-8 h-8 rounded-[var(--radius)] object-cover'
+                  style={{ boxShadow: settings.widget_shadow }}
+                />
+                <div className='min-w-0'>
+                  <div
+                    className='text-sm font-semibold leading-tight truncate'
+                    style={{ color: settings.widget_text_color }}
+                  >
+                    {config.agent_name ?? 'AI Agent'}
+                  </div>
+                  <p className='text-xs opacity-70 truncate' style={{ color: settings.widget_text_color }}>
+                    {config.agent_description ?? 'How can I help?'}
+                  </p>
+                </div>
+              </div>
+              <button
+                type='button'
+                onClick={onClose}
+                className='p-1.5 rounded-full opacity-60 hover:opacity-100 transition-opacity flex-shrink-0'
+                style={{ color: settings.widget_text_color }}
+                aria-label='Close'
+              >
+                <svg className='w-4 h-4' fill='currentColor' viewBox='0 0 20 20'>
+                  <path
+                    fillRule='evenodd'
+                    d='M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z'
+                    clipRule='evenodd'
+                  />
+                </svg>
+              </button>
+            </div>
+
             <div className='flex-1 overflow-hidden flex flex-col min-h-0'>
               <ViewTransition key={activeView} direction={navDirection}>
                 {activeView === 'home' && (
@@ -232,7 +274,6 @@ export const MessengerShell: React.FC<MessengerShellProps> = ({
                     messages={messages}
                     onNavigateToChat={handleNavigateToChat}
                     onChipClick={handleChipClick}
-                    onClose={onClose}
                   />
                 )}
                 {activeView === 'chat' && (

--- a/src/components/views/ChatView.tsx
+++ b/src/components/views/ChatView.tsx
@@ -19,7 +19,6 @@ import { addOpacity } from '../../utils/format';
 import { Button } from '../base/Button';
 import { MessageList } from '../chat/MessageList';
 import { MessageInput } from '../input/MessageInput';
-import { ModeSelector } from '../input/ModeSelector';
 import { ScreenAccessModal } from '../ui/ScreenAccessModal';
 
 class ChatErrorBoundary extends React.Component<{ children: React.ReactNode }, { hasError: boolean }> {
@@ -409,6 +408,18 @@ export const ChatView: React.FC<ChatViewProps> = ({
                     Clear chat
                   </button>
                 )}
+                <button
+                  type='button'
+                  className='w-full text-left px-3 py-2 text-sm hover:bg-gray-100 rounded-md transition-colors'
+                  style={{ color: config.widget_text_color }}
+                  onClick={() => {
+                    window.open('https://marketrix.ai', '_blank', 'noopener,noreferrer');
+                    setMoreMenuOpen(false);
+                  }}
+                  role='menuitem'
+                >
+                  About Marketrix
+                </button>
               </div>
             )}
           </div>
@@ -498,14 +509,10 @@ export const ChatView: React.FC<ChatViewProps> = ({
             onStopTask?.();
           }}
           config={config}
-        />
-
-        <ModeSelector
           currentMode={currentMode}
           enabledModes={getEnabledModes(settings)}
           onModeChange={handleModeChange}
           isScreenSharing={isScreenSharing}
-          config={config}
         />
       </div>
     </div>

--- a/src/components/views/ChatView.tsx
+++ b/src/components/views/ChatView.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
 
-import MarketrixIcon from '../../assets/marketrix-icon.svg';
 import type { InstructionType } from '../../sdk';
 import {
   createScreenAccessRequestMessage,
@@ -101,7 +100,7 @@ export const ChatView: React.FC<ChatViewProps> = ({
   onRemoveMessage,
   onStopTask,
   onClearChat,
-  onClose,
+  onClose: _onClose,
   onScreenSharingChange,
   messageInputRef: externalMessageInputRef,
 }) => {
@@ -324,31 +323,8 @@ export const ChatView: React.FC<ChatViewProps> = ({
 
   return (
     <div className='flex flex-col h-full' id='view-chat' role='tabpanel' aria-labelledby='tab-chat'>
-      {/* Header */}
-      <div
-        className='flex justify-between items-center px-3 py-2 relative border-b rounded-t-[var(--radius)] flex-shrink-0'
-        style={{
-          backgroundColor: 'transparent',
-          borderColor: config.widget_border_color,
-        }}
-      >
-        <div className='flex items-center gap-2 min-w-0 flex-1'>
-          <img
-            src={MarketrixIcon}
-            alt=''
-            className='flex-shrink-0 w-8 h-8 rounded-[var(--radius)] object-cover'
-            style={{ boxShadow: config.widget_shadow }}
-          />
-          <div className='min-w-0'>
-            <div className='text-sm font-semibold leading-tight truncate' style={{ color: config.widget_text_color }}>
-              Marketrix AI
-            </div>
-            <div className='text-xs opacity-70 truncate' style={{ color: config.widget_text_color }}>
-              AI Agent
-            </div>
-          </div>
-        </div>
-
+      {/* Chat toolbar (screen share, more menu) */}
+      <div className='flex justify-end items-center px-3 py-1 flex-shrink-0' style={{ backgroundColor: 'transparent' }}>
         <div className='flex items-center gap-0.5 flex-shrink-0'>
           {config.use_screenshare !== false && !isScreenSharing && (
             <Button
@@ -436,23 +412,6 @@ export const ChatView: React.FC<ChatViewProps> = ({
               </div>
             )}
           </div>
-          <Button
-            type='button'
-            variant='ghost'
-            size='sm'
-            onClick={onClose}
-            className='p-1.5 rounded-full opacity-60 hover:opacity-100 transition-opacity'
-            style={{ color: config.widget_text_color }}
-            aria-label='Close'
-          >
-            <svg className='w-4 h-4' fill='currentColor' viewBox='0 0 20 20'>
-              <path
-                fillRule='evenodd'
-                d='M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z'
-                clipRule='evenodd'
-              />
-            </svg>
-          </Button>
         </div>
       </div>
 

--- a/src/components/views/HomeView.tsx
+++ b/src/components/views/HomeView.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import MarketrixIcon from '../../assets/marketrix-icon.svg';
 import type { ChatMessage, MarketrixConfig } from '../../types';
 import { addOpacity } from '../../utils/format';
 import { getSuggestedActionsFromConfig, type SuggestedActionItem } from '../../utils/suggestedActions';
@@ -11,10 +10,9 @@ interface HomeViewProps {
   messages: ChatMessage[];
   onNavigateToChat: () => void;
   onChipClick: (action: SuggestedActionItem) => void;
-  onClose: () => void;
 }
 
-export const HomeView: React.FC<HomeViewProps> = ({ config, messages, onNavigateToChat, onChipClick, onClose }) => {
+export const HomeView: React.FC<HomeViewProps> = ({ config, messages, onNavigateToChat, onChipClick }) => {
   const suggestedActions = getSuggestedActionsFromConfig(config);
   const accentColor = config.widget_accent_color ?? '#3b82f6';
   const textColor = config.widget_text_color ?? '#1f2937';
@@ -28,45 +26,17 @@ export const HomeView: React.FC<HomeViewProps> = ({ config, messages, onNavigate
 
   return (
     <div className='flex flex-col h-full overflow-hidden' id='view-home' role='tabpanel' aria-labelledby='tab-home'>
-      {/* Header with close button */}
-      <div
-        className='flex justify-between items-center px-3 py-2 border-b flex-shrink-0'
-        style={{ borderColor: config.widget_border_color }}
-      >
-        <div className='flex items-center gap-2 min-w-0 flex-1'>
-          <img
-            src={MarketrixIcon}
-            alt=''
-            className='flex-shrink-0 w-8 h-8 rounded-[var(--radius)] object-cover'
-            style={{ boxShadow: config.widget_shadow }}
-          />
-          <div className='min-w-0'>
-            <div className='text-sm font-semibold leading-tight truncate' style={{ color: textColor }}>
-              {config.widget_greeting ?? 'Hello'}
-            </div>
-            <p className='text-xs opacity-70 truncate' style={{ color: textColor }}>
-              {config.widget_body ?? 'How can we help?'}
-            </p>
-          </div>
-        </div>
-        <button
-          type='button'
-          onClick={onClose}
-          className='p-1.5 rounded-full opacity-60 hover:opacity-100 transition-opacity flex-shrink-0'
-          style={{ color: textColor }}
-          aria-label='Close'
-        >
-          <svg className='w-4 h-4' fill='currentColor' viewBox='0 0 20 20'>
-            <path
-              fillRule='evenodd'
-              d='M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z'
-              clipRule='evenodd'
-            />
-          </svg>
-        </button>
-      </div>
-
       <div className='flex-1 overflow-y-auto p-3 space-y-3'>
+        {/* Centered greeting */}
+        <div className='text-center pt-2'>
+          <h2 className='text-lg font-semibold' style={{ color: textColor }}>
+            {config.widget_greeting ?? 'Hey There!'}
+          </h2>
+          <p className='text-sm opacity-70 mt-1' style={{ color: textColor }}>
+            {config.widget_body ?? 'How can I help you today?'}
+          </p>
+        </div>
+
         {/* Ask a question CTA */}
         <button
           type='button'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -59,6 +59,10 @@ export type MarketrixConfig = Partial<WidgetSettingsData> & {
   show_widget?: boolean;
   /** Controls screen sharing prompts and button. When false, screen access requests are auto-denied and Share Screen button is hidden. Default: true */
   use_screenshare?: boolean;
+
+  // Agent identity fields (passed through from agent settings)
+  agent_name?: string;
+  agent_description?: string;
 };
 
 export interface ChatMessage {


### PR DESCRIPTION
Related: #48

- Unified header: agent name + description on all views, close button
- Home: centered greeting + subtitle, then chips
- Chat: no chips, welcome = widget_body only
- Input: clean textarea + send icon, mode pills inline
- Removed logo from welcome, added About to menu
- Net: -101 lines