### PR TITLE
fix: input focus, send button states, header toolbar, welcome message

### DIFF
--- a/src/components/input/MessageInput.tsx
+++ b/src/components/input/MessageInput.tsx
@@ -111,7 +111,7 @@ export const MessageInput = React.forwardRef<HTMLTextAreaElement, Omit<MessageIn
     <div className='py-1.5 px-2 bg-transparent'>
       <style>{`.message-input-textarea::placeholder { color: ${placeholderColor}; }`}</style>
       <div
-        className='flex flex-col rounded-xl border overflow-hidden'
+        className='flex flex-col rounded-xl border overflow-hidden focus-within:border-gray-300 transition-colors'
         style={{
           borderColor: settings.widget_border_color,
           backgroundColor: 'rgba(255,255,255,0.7)',
@@ -127,7 +127,7 @@ export const MessageInput = React.forwardRef<HTMLTextAreaElement, Omit<MessageIn
           placeholder='Ask anything'
           disabled={isLoading}
           rows={1}
-          className='message-input-textarea w-full px-3 text-sm resize-none focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed border-none overflow-hidden'
+          className='message-input-textarea w-full px-3 text-sm resize-none focus:outline-none focus:ring-0 border-none shadow-none disabled:opacity-50 disabled:cursor-not-allowed overflow-hidden'
           style={{
             backgroundColor: 'transparent',
             color: settings.widget_text_color,
@@ -177,40 +177,29 @@ export const MessageInput = React.forwardRef<HTMLTextAreaElement, Omit<MessageIn
               );
             })}
           </div>
-          {isTaskRunning && onStop ? (
-            <Button
-              type='button'
-              variant='secondary'
-              size='sm'
-              onClick={e => {
-                e.preventDefault();
-                e.stopPropagation();
+          <Button
+            type='button'
+            variant={isTaskRunning ? 'secondary' : 'primary'}
+            size='sm'
+            disabled={!isTaskRunning && !canSend}
+            onClick={e => {
+              e.preventDefault();
+              e.stopPropagation();
+              if (isTaskRunning && onStop) {
                 onStop();
-              }}
-              className='w-7 h-7 min-w-7 rounded-full flex items-center justify-center flex-shrink-0 shadow-lg'
-              style={{
-                background: 'linear-gradient(to right, #1f2937, #111827)',
-                color: '#fff',
-                border: 'none',
-              }}
-              aria-label='Stop task'
-            >
-              <IoStop className='w-3.5 h-3.5' />
-            </Button>
-          ) : (
-            <Button
-              type='button'
-              variant='primary'
-              size='sm'
-              disabled={!canSend}
-              onClick={e => {
-                e.preventDefault();
-                e.stopPropagation();
+              } else {
                 onSend();
-              }}
-              className='w-7 h-7 min-w-7 rounded-full flex items-center justify-center flex-shrink-0'
-              style={
-                canSend
+              }
+            }}
+            className='w-7 h-7 min-w-7 rounded-full flex items-center justify-center flex-shrink-0'
+            style={
+              isTaskRunning
+                ? {
+                    background: 'linear-gradient(to right, #1f2937, #111827)',
+                    color: '#fff',
+                    border: 'none',
+                  }
+                : canSend
                   ? {
                       backgroundColor: settings.widget_accent_color,
                       color: getContrastingColor(settings.widget_accent_color),
@@ -221,14 +210,17 @@ export const MessageInput = React.forwardRef<HTMLTextAreaElement, Omit<MessageIn
                       color: addOpacity(settings.widget_text_color, 0.4),
                       border: 'none',
                     }
-              }
-              aria-label='Send message'
-            >
+            }
+            aria-label={isTaskRunning ? 'Stop task' : 'Send message'}
+          >
+            {isTaskRunning ? (
+              <IoStop className='w-3.5 h-3.5' />
+            ) : (
               <svg className='w-4 h-4' fill='none' stroke='currentColor' viewBox='0 0 24 24' aria-hidden>
-                <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M5 10l7-7m0 0l7 7m-7-7v18' />
+                <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M5 12h14m-7-7l7 7-7 7' />
               </svg>
-            </Button>
-          )}
+            )}
+          </Button>
         </div>
       </div>
     </div>

--- a/src/components/navigation/MessengerShell.tsx
+++ b/src/components/navigation/MessengerShell.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import MarketrixIcon from '../../assets/marketrix-icon.svg';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
@@ -9,6 +9,7 @@ import type { ChatMessage, InstructionType, MarketrixConfig, TaskProgress, Widge
 import { addOpacity } from '../../utils/format';
 import type { SuggestedActionItem } from '../../utils/suggestedActions';
 import { getPanelPositionStyle } from '../../utils/widgetPositioning';
+import { Button } from '../base/Button';
 import { ChatView } from '../views/ChatView';
 import { HomeView } from '../views/HomeView';
 import { TabBar } from './TabBar';
@@ -177,6 +178,33 @@ export const MessengerShell: React.FC<MessengerShellProps> = ({
     onSendMessage(action.text, action.type, undefined, undefined, true);
   };
 
+  // Header menu + screen share state (lifted from ChatView)
+  const [moreMenuOpen, setMoreMenuOpen] = useState(false);
+  const [headerScreenSharing, setHeaderScreenSharing] = useState(false);
+  const moreMenuRef = useRef<HTMLDivElement>(null);
+  const chatViewStartScreenShareRef = useRef<(() => void) | null>(null);
+  const chatViewStopScreenShareRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (moreMenuRef.current && !moreMenuRef.current.contains(e.target as Node)) {
+        setMoreMenuOpen(false);
+      }
+    };
+    if (moreMenuOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [moreMenuOpen]);
+
+  const handleHeaderScreenSharingChange = useCallback(
+    (isSharing: boolean) => {
+      setHeaderScreenSharing(isSharing);
+      onScreenSharingChange?.(isSharing);
+    },
+    [onScreenSharingChange],
+  );
+
   return (
     <div
       className={`${positionClass} rounded-[var(--radius)] pointer-events-auto`}
@@ -249,21 +277,125 @@ export const MessengerShell: React.FC<MessengerShellProps> = ({
                   </p>
                 </div>
               </div>
-              <button
-                type='button'
-                onClick={onClose}
-                className='p-1.5 rounded-full opacity-60 hover:opacity-100 transition-opacity flex-shrink-0'
-                style={{ color: settings.widget_text_color }}
-                aria-label='Close'
-              >
-                <svg className='w-4 h-4' fill='currentColor' viewBox='0 0 20 20'>
-                  <path
-                    fillRule='evenodd'
-                    d='M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z'
-                    clipRule='evenodd'
-                  />
-                </svg>
-              </button>
+              <div className='flex items-center gap-0.5 flex-shrink-0'>
+                {activeView === 'chat' && (
+                  <>
+                    {config.use_screenshare !== false && !headerScreenSharing && (
+                      <Button
+                        type='button'
+                        variant='ghost'
+                        size='sm'
+                        onClick={() => chatViewStartScreenShareRef.current?.()}
+                        className='p-1.5 rounded-full opacity-60 hover:opacity-100 transition-opacity'
+                        style={{ color: settings.widget_text_color }}
+                        aria-label='Start screen sharing'
+                        title='Share screen'
+                      >
+                        <svg className='w-4 h-4' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
+                          <path
+                            strokeLinecap='round'
+                            strokeLinejoin='round'
+                            strokeWidth={2}
+                            d='M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z'
+                          />
+                        </svg>
+                      </Button>
+                    )}
+                    {headerScreenSharing && (
+                      <Button
+                        type='button'
+                        variant='ghost'
+                        size='sm'
+                        onClick={() => chatViewStopScreenShareRef.current?.()}
+                        className='p-1.5 rounded-full opacity-80 hover:opacity-100 transition-opacity flex items-center gap-1'
+                        style={{ color: settings.widget_text_color }}
+                        aria-label='Stop screen sharing'
+                        title='Stop screen sharing'
+                      >
+                        <span className='w-1.5 h-1.5 rounded-full bg-current animate-pulse' />
+                        <svg className='w-4 h-4' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
+                          <path
+                            strokeLinecap='round'
+                            strokeLinejoin='round'
+                            strokeWidth={2}
+                            d='M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z'
+                          />
+                        </svg>
+                      </Button>
+                    )}
+                    <div className='relative' ref={moreMenuRef}>
+                      <Button
+                        type='button'
+                        variant='ghost'
+                        size='sm'
+                        onClick={() => setMoreMenuOpen(prev => !prev)}
+                        className='p-1.5 rounded-full opacity-60 hover:opacity-100 transition-opacity'
+                        style={{ color: settings.widget_text_color }}
+                        aria-label='More options'
+                        aria-haspopup='true'
+                        aria-expanded={moreMenuOpen}
+                      >
+                        <svg className='w-4 h-4' fill='currentColor' viewBox='0 0 20 20'>
+                          <path d='M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z' />
+                        </svg>
+                      </Button>
+                      {moreMenuOpen && (
+                        <div
+                          className='absolute right-0 top-full mt-1 py-1 rounded-lg shadow-lg border min-w-[140px] z-50'
+                          style={{
+                            backgroundColor: '#ffffff',
+                            borderColor: settings.widget_border_color,
+                          }}
+                          role='menu'
+                        >
+                          {onClearChat && (
+                            <button
+                              type='button'
+                              className='w-full text-left px-3 py-2 text-sm hover:bg-gray-100 rounded-md transition-colors'
+                              style={{ color: settings.widget_text_color }}
+                              onClick={() => {
+                                const result = onClearChat();
+                                if (result instanceof Promise) result.catch(e => console.error(e));
+                                setMoreMenuOpen(false);
+                              }}
+                              role='menuitem'
+                            >
+                              Clear chat
+                            </button>
+                          )}
+                          <button
+                            type='button'
+                            className='w-full text-left px-3 py-2 text-sm hover:bg-gray-100 rounded-md transition-colors'
+                            style={{ color: settings.widget_text_color }}
+                            onClick={() => {
+                              window.open('https://marketrix.ai', '_blank', 'noopener,noreferrer');
+                              setMoreMenuOpen(false);
+                            }}
+                            role='menuitem'
+                          >
+                            About Marketrix
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  </>
+                )}
+                <button
+                  type='button'
+                  onClick={onClose}
+                  className='p-1.5 rounded-full opacity-60 hover:opacity-100 transition-opacity flex-shrink-0'
+                  style={{ color: settings.widget_text_color }}
+                  aria-label='Close'
+                >
+                  <svg className='w-4 h-4' fill='currentColor' viewBox='0 0 20 20'>
+                    <path
+                      fillRule='evenodd'
+                      d='M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z'
+                      clipRule='evenodd'
+                    />
+                  </svg>
+                </button>
+              </div>
             </div>
 
             <div className='flex-1 overflow-hidden flex flex-col min-h-0'>
@@ -291,7 +423,9 @@ export const MessengerShell: React.FC<MessengerShellProps> = ({
                     onStopTask={onStopTask}
                     onClearChat={onClearChat}
                     onClose={onClose}
-                    onScreenSharingChange={onScreenSharingChange}
+                    onScreenSharingChange={handleHeaderScreenSharingChange}
+                    onStartScreenShareRef={chatViewStartScreenShareRef}
+                    onStopScreenShareRef={chatViewStopScreenShareRef}
                     messageInputRef={messageInputRef}
                   />
                 )}

--- a/src/components/views/ChatView.tsx
+++ b/src/components/views/ChatView.tsx
@@ -16,7 +16,6 @@ import {
 import { showModeService } from '../../services/ShowModeService';
 import type { ChatMessage, MarketrixConfig, TaskProgress } from '../../types';
 import { addOpacity } from '../../utils/format';
-import { Button } from '../base/Button';
 import { MessageList } from '../chat/MessageList';
 import { MessageInput } from '../input/MessageInput';
 import { ScreenAccessModal } from '../ui/ScreenAccessModal';
@@ -68,6 +67,9 @@ export interface ChatViewProps {
   onClearChat?: () => void | Promise<void>;
   onClose: () => void;
   onScreenSharingChange?: (isSharing: boolean) => void;
+  /** Refs for header buttons to trigger screen share start/stop */
+  onStartScreenShareRef?: React.MutableRefObject<(() => void) | null>;
+  onStopScreenShareRef?: React.MutableRefObject<(() => void) | null>;
   /** Optional ref for focus trap to focus the message input */
   messageInputRef?: React.RefObject<HTMLTextAreaElement | null>;
 }
@@ -98,9 +100,11 @@ export const ChatView: React.FC<ChatViewProps> = ({
   onUpdateMessage,
   onRemoveMessage,
   onStopTask,
-  onClearChat,
+  onClearChat: _onClearChat,
   onClose: _onClose,
   onScreenSharingChange,
+  onStartScreenShareRef,
+  onStopScreenShareRef,
   messageInputRef: externalMessageInputRef,
 }) => {
   const [inputValue, setInputValue] = useState('');
@@ -109,8 +113,6 @@ export const ChatView: React.FC<ChatViewProps> = ({
   const [screenShareMessageId, setScreenShareMessageId] = useState<string | null>(null);
   const [screenAccessRequestMessageId, setScreenAccessRequestMessageId] = useState<string | null>(null);
   const [showScreenAccessModal, setShowScreenAccessModal] = useState(false);
-  const [moreMenuOpen, setMoreMenuOpen] = useState(false);
-  const moreMenuRef = useRef<HTMLDivElement>(null);
 
   const [pendingMessage, setPendingMessage] = useState<{
     content: string;
@@ -163,18 +165,6 @@ export const ChatView: React.FC<ChatViewProps> = ({
     const interval = setInterval(checkScreenSharing, 1000);
     return () => clearInterval(interval);
   }, []);
-
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (moreMenuRef.current && !moreMenuRef.current.contains(e.target as Node)) {
-        setMoreMenuOpen(false);
-      }
-    };
-    if (moreMenuOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
-      return () => document.removeEventListener('mousedown', handleClickOutside);
-    }
-  }, [moreMenuOpen]);
 
   const requestScreenAccess = (mode: InstructionType) => {
     if (screenAccessRequestMessageId) return;
@@ -313,6 +303,16 @@ export const ChatView: React.FC<ChatViewProps> = ({
     setScreenShareMessageId(null);
   };
 
+  // Expose screen share handlers to MessengerShell header via refs
+  useEffect(() => {
+    if (onStartScreenShareRef) onStartScreenShareRef.current = handleStartScreenShare;
+    if (onStopScreenShareRef) onStopScreenShareRef.current = stopScreenSharing;
+    return () => {
+      if (onStartScreenShareRef) onStartScreenShareRef.current = null;
+      if (onStopScreenShareRef) onStopScreenShareRef.current = null;
+    };
+  });
+
   const settings = config as MarketrixConfig & {
     widget_greeting?: string;
     widget_feature_show?: boolean;
@@ -322,110 +322,6 @@ export const ChatView: React.FC<ChatViewProps> = ({
 
   return (
     <div className='flex flex-col h-full' id='view-chat' role='tabpanel' aria-labelledby='tab-chat'>
-      {/* Chat toolbar (screen share, more menu) */}
-      <div className='flex justify-end items-center px-3 py-1 flex-shrink-0' style={{ backgroundColor: 'transparent' }}>
-        <div className='flex items-center gap-0.5 flex-shrink-0'>
-          {config.use_screenshare !== false && !isScreenSharing && (
-            <Button
-              type='button'
-              variant='ghost'
-              size='sm'
-              onClick={handleStartScreenShare}
-              className='p-1.5 rounded-full opacity-60 hover:opacity-100 transition-opacity'
-              style={{ color: config.widget_text_color }}
-              aria-label='Start screen sharing'
-              title='Share screen'
-            >
-              <svg className='w-4 h-4' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-                <path
-                  strokeLinecap='round'
-                  strokeLinejoin='round'
-                  strokeWidth={2}
-                  d='M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z'
-                />
-              </svg>
-            </Button>
-          )}
-          {isScreenSharing && (
-            <Button
-              type='button'
-              variant='ghost'
-              size='sm'
-              onClick={stopScreenSharing}
-              className='p-1.5 rounded-full opacity-80 hover:opacity-100 transition-opacity flex items-center gap-1'
-              style={{ color: config.widget_text_color }}
-              aria-label='Stop screen sharing'
-              title='Stop screen sharing'
-            >
-              <span className='w-1.5 h-1.5 rounded-full bg-current animate-pulse' />
-              <svg className='w-4 h-4' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-                <path
-                  strokeLinecap='round'
-                  strokeLinejoin='round'
-                  strokeWidth={2}
-                  d='M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z'
-                />
-              </svg>
-            </Button>
-          )}
-          <div className='relative' ref={moreMenuRef}>
-            <Button
-              type='button'
-              variant='ghost'
-              size='sm'
-              onClick={() => setMoreMenuOpen(prev => !prev)}
-              className='p-1.5 rounded-full opacity-60 hover:opacity-100 transition-opacity'
-              style={{ color: config.widget_text_color }}
-              aria-label='More options'
-              aria-haspopup='true'
-              aria-expanded={moreMenuOpen}
-            >
-              <svg className='w-4 h-4' fill='currentColor' viewBox='0 0 20 20'>
-                <path d='M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z' />
-              </svg>
-            </Button>
-            {moreMenuOpen && (
-              <div
-                className='absolute right-0 top-full mt-1 py-1 rounded-lg shadow-lg border min-w-[140px] z-50'
-                style={{
-                  backgroundColor: '#ffffff',
-                  borderColor: config.widget_border_color,
-                }}
-                role='menu'
-              >
-                {onClearChat && (
-                  <button
-                    type='button'
-                    className='w-full text-left px-3 py-2 text-sm hover:bg-gray-100 rounded-md transition-colors'
-                    style={{ color: config.widget_text_color }}
-                    onClick={() => {
-                      const result = onClearChat();
-                      if (result instanceof Promise) result.catch(e => console.error(e));
-                      setMoreMenuOpen(false);
-                    }}
-                    role='menuitem'
-                  >
-                    Clear chat
-                  </button>
-                )}
-                <button
-                  type='button'
-                  className='w-full text-left px-3 py-2 text-sm hover:bg-gray-100 rounded-md transition-colors'
-                  style={{ color: config.widget_text_color }}
-                  onClick={() => {
-                    window.open('https://marketrix.ai', '_blank', 'noopener,noreferrer');
-                    setMoreMenuOpen(false);
-                  }}
-                  role='menuitem'
-                >
-                  About Marketrix
-                </button>
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
-
       {showScreenAccessModal && (
         <ScreenAccessModal
           isOpen={showScreenAccessModal}


### PR DESCRIPTION
- Remove ugly focus border on chat textarea
- Send button always visible: disabled→enabled→stop based on state
- Arrow icon horizontal (left-to-right)
- Video + ellipsis buttons moved to shared header row (same row as close)
- Chat welcome message uses widget_body not widget_greeting