### PR TITLE
chore(sdk): mirror QA schema — drop executions and progress_log

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@marketrix.ai/widget",
-  "version": "3.3.65",
+  "version": "3.3.66",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@marketrix.ai/widget",
-      "version": "3.3.65",
+      "version": "3.3.66",
       "dependencies": {
         "@base-ui/react": "^1.4.0",
         "@orpc/client": "^1.13.14",

--- a/src/sdk/schema.ts
+++ b/src/sdk/schema.ts
@@ -425,26 +425,6 @@ export const QARunEntitySchema = BaseEntitySchema.extend({
 /**
  * JSON entry schemas for qa_test_case embedded arrays
  */
-export const QAProgressLogEntrySchema = z.object({
-  step: z.number(),
-  message: z.string(),
-  timestamp: z.string(),
-  status: z.enum(['success', 'error', 'info']),
-});
-
-export const QAExecutionEntrySchema = z.object({
-  run_id: z.number(),
-  status: z.enum(['pending', 'in_progress', 'passed', 'failed', 'skipped', 'completed']),
-  browser_type: BrowserTypeSchema.nullish(),
-  progress_log: z.array(QAProgressLogEntrySchema).default([]),
-  error_message: z.string().nullish(),
-  screenshot_url: z.string().nullish(),
-  simulation_id: z.number().nullish(),
-  duration_ms: z.number().nullish(),
-  started_at: z.string().nullish(),
-  completed_at: z.string().nullish(),
-});
-
 export const QAVersionHistoryEntrySchema = z.object({
   version: z.number().int().positive(),
   test_title: z.string(),
@@ -486,7 +466,6 @@ export const QATestCaseEntitySchema = BaseEntitySchema.extend({
   is_active: z.preprocess(v => (typeof v === 'number' ? v !== 0 : v), z.boolean()),
   current_version: z.number().int().positive(),
   version_history: z.array(QAVersionHistoryEntrySchema).nullable(),
-  executions: z.array(QAExecutionEntrySchema).nullable(),
   healing_attempts: z.array(QAHealingAttemptEntrySchema).nullable(),
   healing_metadata: z.record(z.string(), z.unknown()).nullish(),
   last_healed_at: z.coerce.date().nullish(),
@@ -602,7 +581,6 @@ export type QAFailureType = z.infer<typeof QAFailureTypeSchema>;
 export type QAValidationStatus = z.infer<typeof QAValidationStatusSchema>;
 export type QAHealingMetadata = z.infer<typeof QAHealingMetadataSchema>;
 export type FailureAnalysis = z.infer<typeof FailureAnalysisSchema>;
-export type QAExecutionEntry = z.infer<typeof QAExecutionEntrySchema>;
 export type QAVersionHistoryEntry = z.infer<typeof QAVersionHistoryEntrySchema>;
 export type QAHealingAttemptEntry = z.infer<typeof QAHealingAttemptEntrySchema>;
 


### PR DESCRIPTION
## Summary

Shared-contract mirror of the api schema change — drops `QAProgressLogEntrySchema`, `QAExecutionEntrySchema`, the `QAExecutionEntry` type export, and the `executions` field from `QATestCaseEntitySchema`.

Widget doesn't consume QA execution data directly, but the shared-contract rule in root `CLAUDE.md` requires the schema mirror stays in sync with `api/schema.ts`.

## Test plan

- [x] Type-check clean
- [x] Pre-commit hooks (check + lint) pass
- [ ] CI green
- [ ] Coordinated with api + app PRs

Depends on api PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)