### PR TITLE
chore(sdk): mirror has_question task status

### DIFF
--- a/src/sdk/schema.ts
+++ b/src/sdk/schema.ts
@@ -849,7 +849,7 @@ export const SimulationTaskEntrySchema = z.object({
   task_id: z.string(),
   title: z.string(),
   instructions: z.string(),
-  status: z.enum(['pending', 'in_progress', 'passed', 'failed', 'skipped', 'stopped']),
+  status: z.enum(['pending', 'in_progress', 'has_question', 'passed', 'failed', 'skipped', 'stopped']),
   error_message: z.string().nullish(),
   started_at: z.string().nullish(),
   completed_at: z.string().nullish(),


### PR DESCRIPTION
Shared-contract mirror of the api schema change. `SimulationTaskEntry.status` now includes `has_question` — a transient status used by the flow to keep the watchdog from killing sims while the agent is paused waiting on a user answer.