### PR TITLE
[Feature] - Integrate viewport dimensions into session recording telemetry

### DIFF
--- a/src/sdk/schema.ts
+++ b/src/sdk/schema.ts
@@ -1463,6 +1463,13 @@ export const WidgetCommandSchema = z.discriminatedUnion('type', [
     url: z.string().optional(),
     user_agent: z.string().optional(),
     timestamp: z.number().optional(),
+    viewport: z
+      .object({
+        width: z.number(),
+        height: z.number(),
+        dpr: z.number().optional(),
+      })
+      .optional(),
   }),
   z.object({
     type: z.literal('rrweb/events'),

--- a/src/sdk/schema.ts
+++ b/src/sdk/schema.ts
@@ -1467,7 +1467,6 @@ export const WidgetCommandSchema = z.discriminatedUnion('type', [
       .object({
         width: z.number(),
         height: z.number(),
-        dpr: z.number().optional(),
       })
       .optional(),
   }),

--- a/src/services/SessionRecorder.ts
+++ b/src/services/SessionRecorder.ts
@@ -90,7 +90,6 @@ export class SessionRecorder {
         viewport: {
           width: window.innerWidth,
           height: window.innerHeight,
-          dpr: window.devicePixelRatio,
         },
       },
     });

--- a/src/services/SessionRecorder.ts
+++ b/src/services/SessionRecorder.ts
@@ -87,6 +87,11 @@ export class SessionRecorder {
         url: window.location.href,
         user_agent: navigator.userAgent,
         timestamp: Date.now(),
+        viewport: {
+          width: window.innerWidth,
+          height: window.innerHeight,
+          dpr: window.devicePixelRatio,
+        },
       },
     });
 


### PR DESCRIPTION
## Summary
This PR introduces viewport dimension tracking within the session recording lifecycle. By capturing the user's browser `width` and `height` at the time of command execution, we provide essential context for downstream features such as heatmap generation and layout-relative interaction analysis. 

The implementation updates the `WidgetCommandSchema` to include an optional `viewport` object and modifies the `SessionRecorder` service to automatically populate these values using the current window dimensions. Note that while `devicePixelRatio` (DPR) was initially considered, it has been intentionally omitted to keep the telemetry payload lean and focused on core layout metrics.

## Related issue
<!-- Use Closes/Fixes/Resolves to link. project-sync moves the linked issue to In Progress. -->
<!-- Closes # -->

## Test plan
- [ ] Verify that session recording payloads now include a `viewport` object with valid `width` and `height` integers.
- [ ] Validate that the Zod schema correctly parses incoming commands with and without the optional `viewport` field.
- [ ] Confirm that `window.innerWidth` and `window.innerHeight` are correctly captured across different browser window sizes.

## Checklist
- [x] CI passes (type-check + lint)
- [x] Shared contracts in sync if changed (`routes.ts`, `schema.ts`, `proto`)