### PR TITLE
chore(sdk): mirror insightPersonasRegenerate

### DIFF
--- a/src/sdk/routes.ts
+++ b/src/sdk/routes.ts
@@ -2757,6 +2757,16 @@ const contract = {
     .input(z.object({ id: z.coerce.number() }))
     .output(SuccessSchema),
 
+  insightPersonasRegenerate: oc
+    .route({
+      method: 'POST',
+      tags: ['Insight'],
+      path: '/insights/personas/regenerate',
+      summary: 'Start segment + persona regeneration for an application (fire-and-forget)',
+    })
+    .input(z.object({ application_id: z.number() }))
+    .output(z.object({ job_id: z.string() })),
+
   // Heatmaps
   insightHeatmapPages: oc
     .route({


### PR DESCRIPTION
Contract-only SDK mirror to keep widget in sync with api per `CLAUDE.md` convention. Widget does not call this endpoint at runtime, but the contract stays mirrored to keep drift alarms quiet.

Mirrors https://github.com/Marketrix-ai/api/pull/291.

## Test plan

- [x] `npm run type-check` green
- [x] No runtime changes (contract-only addition)