### PR TITLE
Phase 0: mirror KnowledgeSourceSchema into widget SDK

### DIFF
--- a/src/sdk/schema.ts
+++ b/src/sdk/schema.ts
@@ -49,6 +49,7 @@ export const LearningProgressSchema = z.object({
   graph_index_created: z.boolean().nullable(),
 });
 export const KnowledgeTypeSchema = z.enum(['document', 'video']);
+export const KnowledgeSourceSchema = z.enum(['user', 'research']);
 export const QAFlowStatusSchema = z.enum(['pending', 'processing', 'waiting_review', 'completed', 'failed']);
 export const QATestStatusSchema = z.enum(['pending', 'in_progress', 'completed', 'failed']);
 export const QARunStatusSchema = z.enum(['pending', 'in_progress', 'completed', 'failed', 'stopped']);
@@ -354,6 +355,7 @@ export const KnowledgeEntitySchema = BaseEntitySchema.extend({
   file_type: KnowledgeTypeSchema,
   file_url: z.string(),
   source_url: z.string().nullish(), // Original URL for URL-based documents
+  source: KnowledgeSourceSchema.default('user').optional(),
   agents: z.array(AgentBadgeSchema).optional(),
 });
 
@@ -2357,6 +2359,7 @@ export type AgentType = z.infer<typeof AgentTypeSchema>;
 export type AgentVoice = z.infer<typeof AgentVoiceSchema>;
 export type AgentStatus = z.infer<typeof AgentStatusSchema>;
 export type KnowledgeType = z.infer<typeof KnowledgeTypeSchema>;
+export type KnowledgeSource = z.infer<typeof KnowledgeSourceSchema>;
 export type ChatStatus = z.infer<typeof ChatRoleSchema>;
 export type ChatSource = z.infer<typeof ChatSourceSchema>;
 export type InstructionType = z.infer<typeof InstructionTypeSchema>;


### PR DESCRIPTION
Closes #101

## Summary
Mirrors the three schema additions that landed in app PR #420 (app-side mirror) into the widget SDK to keep shared contracts in sync with `api/schema.ts`:

- New `KnowledgeSourceSchema` enum (`'user' | 'research'`)
- `KnowledgeEntitySchema` extended with optional `source` field: `KnowledgeSourceSchema.default('user').optional()`
- New `KnowledgeSource` derived type export

## Scope
- Pure schema-sync change. Widget has no current consumer of knowledge items — the added symbol is inert until a future feature uses it.
- Backwards-compatible addition (`.optional()`), so existing npm consumers (notably `app`) do not need a re-bump.

## Plan
- Modify `src/sdk/schema.ts` only.
- Run `npm run type-check` and `npm run code:check`.

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run code:check` passes
- [x] `package-lock.json` unchanged after `npm install`