### PR TITLE
Sync InsightPersonaEntitySchema: add Big 5 + MBTI fields

### DIFF
--- a/src/sdk/schema.ts
+++ b/src/sdk/schema.ts
@@ -2689,6 +2689,13 @@ export const InsightPersonaEntitySchema = z.object({
   initials: z.string(),
   description: z.string(),
   traits: z.array(z.string()),
+  openness: z.number().nullable().optional(),
+  conscientiousness: z.number().nullable().optional(),
+  extraversion: z.number().nullable().optional(),
+  agreeableness: z.number().nullable().optional(),
+  neuroticism: z.number().nullable().optional(),
+  mbti_type: z.string().optional().default(''),
+  mbti_rationale: z.string().optional().default(''),
   created_at: z.coerce.date().optional(),
   updated_at: z.coerce.date().optional(),
 });


### PR DESCRIPTION
## Summary
Adds 7 new personality fields to `InsightPersonaEntitySchema` in `src/sdk/schema.ts` to keep it in sync with `api/schema.ts` (post Big 5 + MBTI work).

Note: the wider widget-vs-api schema drift on this entity (missing `is_selected`, `is_top`, `tags`, `source`, and the PR #300 profile fields) is pre-existing and **out of scope** for this change. Widget schema is consumed via `.optional()` in routes that the widget doesn't call at runtime; bringing it fully in sync is separate cleanup.

## Test plan
- [x] tsc clean

## Checklist
- [x] CI passes