### PR TITLE
chore(sdk): sync new persona fields from api

### DIFF
--- a/src/sdk/schema.ts
+++ b/src/sdk/schema.ts
@@ -2696,6 +2696,11 @@ export const InsightPersonaEntitySchema = z.object({
   neuroticism: z.number().nullable().optional(),
   mbti_type: z.string().optional().default(''),
   mbti_rationale: z.string().optional().default(''),
+  key_features: z.array(z.string()).optional().default([]),
+  bhvr_proficiency: z.number().nullable().optional(),
+  bhvr_preciseness: z.number().nullable().optional(),
+  bhvr_sensitivity: z.number().nullable().optional(),
+  bhvr_efficiency: z.number().nullable().optional(),
   created_at: z.coerce.date().optional(),
   updated_at: z.coerce.date().optional(),
 });


### PR DESCRIPTION
Mirrors new persona fields added in api/schema.ts (CLAUDE.md contract sync rule):

- key_features (string array)
- bhvr_proficiency, bhvr_preciseness, bhvr_sensitivity, bhvr_efficiency (0-100 scores)

Schema-only change. Widget runtime does not call any persona endpoints today; this keeps the entity contract aligned for future use and downstream type-checks.

Coordinates with:
- api PR #330: api/schema.ts adds these fields
- app PR #464: app/sdk/schema.ts mirrors them
- agent PR #122: agent populates them at persona generation time