### PR TITLE
chore(sdk): resync mirrors from api, preserve Uint8Array divergence

### DIFF
--- a/src/sdk/routes.ts
+++ b/src/sdk/routes.ts
@@ -81,6 +81,7 @@ import {
   ConnectorUpsertSchema,
   ContextRefSchema,
   DiffValueSchema,
+  DomainPersonaSuggestResponseSchema,
   EntityStatusSchema,
   FailureAnalysisSchema,
   FileSchema,
@@ -88,6 +89,8 @@ import {
   GithubRepoSchema,
   GithubWorkflowRunSchema,
   HealthResponseSchema,
+  HeatmapCandidateSchema,
+  HeatmapJobStatusSchema,
   HeatmapPageEntitySchema,
   HeatmapSnapshotEntitySchema,
   HeatmapTypeSchema,
@@ -95,6 +98,8 @@ import {
   IndexResponseSchema,
   InsightPersonaEntitySchema,
   InsightPersonasResponseSchema,
+  InsightPersonasSaveDomainInputSchema,
+  InsightPersonaUpdateInputSchema,
   InsightSegmentEntitySchema,
   KnowledgeEntitySchema,
   KnowledgeTypeSchema,
@@ -120,6 +125,7 @@ import {
   QAHealingAttemptEntrySchema,
   QARunEntitySchema,
   QATestCaseEntitySchema,
+  QATestVerdictEntitySchema,
   QAVersionHistoryEntrySchema,
   ReactionEntitySchema,
   ReactionRunEntitySchema,
@@ -2128,12 +2134,13 @@ const contract = {
       method: 'PUT',
       tags: ['QA'],
       path: '/qa/document/{id}',
-      summary: 'Update QA flow status',
-      description: 'Updates the status of a QA flow',
+      summary: 'Update QA flow',
+      description: 'Updates status and/or pinned state of a QA flow',
     })
     .input(
       ByIdSchema.extend({
-        status: QAFlowStatusSchema,
+        status: QAFlowStatusSchema.optional(),
+        pinned: z.boolean().optional(),
       }),
     )
     .output(QAFlowEntitySchema),
@@ -2150,6 +2157,7 @@ const contract = {
     .output(
       paginatedListOf(
         QARunEntitySchema.extend({
+          status: z.string(),
           total_tests: z.number(),
           passed: z.number(),
           failed: z.number(),
@@ -2172,6 +2180,17 @@ const contract = {
       }),
     ),
 
+  qaRunVerdicts: oc
+    .route({
+      method: 'GET',
+      tags: ['QA'],
+      path: '/qa/run/{run_id}/verdicts',
+      summary: 'Get evaluator verdicts for a QA run',
+      description: 'Returns all qa_test_verdict rows for a run, keyed by test case',
+    })
+    .input(z.object({ run_id: z.coerce.number() }))
+    .output(z.array(QATestVerdictEntitySchema)),
+
   qaRunDelete: oc
     .route({
       method: 'DELETE',
@@ -2191,7 +2210,12 @@ const contract = {
       summary: 'Create and start a new QA run',
       description: 'Creates a new run and starts execution. Returns 202; poll test-cases for execution status.',
     })
-    .input(ByIdSchema)
+    .input(
+      ByIdSchema.extend({
+        auto_heal: z.boolean().default(false),
+        auto_accept: z.boolean().default(false),
+      }),
+    )
     .output(
       z.object({
         run: QARunEntitySchema,
@@ -2757,6 +2781,46 @@ const contract = {
     .input(z.object({ id: z.coerce.number() }))
     .output(SuccessSchema),
 
+  insightPersonasDomainSuggest: oc
+    .route({
+      method: 'GET',
+      tags: ['Insight'],
+      path: '/insights/personas/domain-suggest',
+      summary: 'Get domain-specific persona suggestions (accessible during onboarding)',
+    })
+    .input(z.object({ domain: z.string() }))
+    .output(DomainPersonaSuggestResponseSchema),
+
+  insightPersonasSaveDomain: oc
+    .route({
+      method: 'POST',
+      tags: ['Insight'],
+      path: '/insights/personas/save-domain',
+      summary: 'Save domain-suggested personas to the workspace (accessible during onboarding)',
+    })
+    .input(InsightPersonasSaveDomainInputSchema)
+    .output(z.object({ saved: z.number() })),
+
+  insightPersonaUpdate: oc
+    .route({
+      method: 'PATCH',
+      tags: ['Insight'],
+      path: '/insights/personas/{id}',
+      summary: 'Update persona content (name, description, profile fields, tags, traits)',
+    })
+    .input(InsightPersonaUpdateInputSchema)
+    .output(SuccessSchema),
+
+  insightPersonaUpdateSelection: oc
+    .route({
+      method: 'PATCH',
+      tags: ['Insight'],
+      path: '/insights/personas/{id}/selection',
+      summary: 'Toggle the is_selected state of a persona',
+    })
+    .input(z.object({ id: z.coerce.number(), is_selected: z.boolean() }))
+    .output(SuccessSchema),
+
   insightPersonasRegenerate: oc
     .route({
       method: 'POST',
@@ -2766,6 +2830,16 @@ const contract = {
     })
     .input(z.object({ application_id: z.number() }))
     .output(z.object({ job_id: z.string() })),
+
+  insightPersonaKeyFeatures: oc
+    .route({
+      method: 'POST',
+      tags: ['Insight'],
+      path: '/insights/personas/{id}/key-features',
+      summary: 'Generate AI key product feature insights for a specific persona',
+    })
+    .input(z.object({ id: z.coerce.number() }))
+    .output(z.object({ features: z.array(z.string()) })),
 
   insightResearchRun: oc
     .route({
@@ -2778,6 +2852,18 @@ const contract = {
     })
     .input(z.object({ application_id: z.coerce.number() }))
     .output(z.object({ job_id: z.string() })),
+
+  insightResearchStatus: oc
+    .route({
+      method: 'POST',
+      tags: ['Insight'],
+      path: '/insights/{application_id}/research/status',
+      summary: 'Check whether Background Research is currently running',
+      description:
+        'Returns the current Background Research dispatch state for an application. Used by the client to restore the "Researching…" banner across page refreshes — if `status="in_progress"`, the client subscribes to appEvents and waits for `job/completed`. Per-pod tracking; not persistent across api restarts.',
+    })
+    .input(z.object({ application_id: z.coerce.number() }))
+    .output(z.object({ status: z.enum(['idle', 'in_progress']) })),
 
   // Heatmaps
   insightHeatmapPages: oc
@@ -2805,10 +2891,58 @@ const contract = {
       method: 'POST',
       tags: ['Insight'],
       path: '/insights/heatmaps/generate',
-      summary: 'Generate heatmap data from sessions (mocked)',
+      summary: 'Enqueue a heatmap aggregation job over RRWeb session batches',
     })
     .input(ByApplicationIdSchema)
-    .output(SuccessSchema),
+    .output(z.object({ job_id: z.string(), status: z.enum(['queued', 'active']) })),
+
+  insightHeatmapsStatus: oc
+    .route({
+      method: 'GET',
+      tags: ['Insight'],
+      path: '/insights/heatmaps/status',
+      summary: 'Get the current heatmap aggregation job status for an application',
+    })
+    .input(ByApplicationIdSchema)
+    .output(HeatmapJobStatusSchema),
+
+  insightHeatmapCandidates: oc
+    .route({
+      method: 'POST',
+      tags: ['Insight'],
+      path: '/insights/heatmaps/candidates',
+      summary: 'Live-scan contributing sessions for a (page, variation) snapshot',
+    })
+    .input(
+      z.object({
+        page_id: z.number(),
+        variation: HeatmapVariationSchema,
+        limit: z.number().int().min(1).max(50).default(15),
+        offset: z.number().int().min(0).default(0),
+      }),
+    )
+    .output(
+      z.object({
+        candidates: z.array(HeatmapCandidateSchema),
+        total: z.number(),
+      }),
+    ),
+
+  insightHeatmapSetBackdrop: oc
+    .route({
+      method: 'POST',
+      tags: ['Insight'],
+      path: '/insights/heatmaps/backdrop',
+      summary: 'Pin a session as the backdrop override for a (page, variation) snapshot, or clear it with null',
+    })
+    .input(
+      z.object({
+        page_id: z.number(),
+        variation: HeatmapVariationSchema,
+        session_id: z.string().nullable(),
+      }),
+    )
+    .output(z.object({ success: z.literal(true) })),
 
   // Reactions
   insightReactionsGet: oc

--- a/src/sdk/schema.ts
+++ b/src/sdk/schema.ts
@@ -395,8 +395,11 @@ export const QAFlowEntitySchema = BaseEntitySchema.extend({
   additional_instructions: z.string().max(1000).nullish(),
   status: QAFlowStatusSchema,
   processing_step: z.string().nullish(),
+  processing_started_at: z.coerce.date().nullish(),
   ultimate_goal: z.string().nullish(),
   browser_config: BrowserConfigSchema.nullish(),
+  persona_ids: z.array(z.coerce.number()).optional().default([]),
+  pinned: z.boolean().optional().default(false),
 });
 
 /**
@@ -408,6 +411,7 @@ export const QAFlowCreateSchema = z.object({
   text_content: z.string().optional(),
   file_name: z.string().optional(),
   additional_instructions: z.string().max(1000).optional(),
+  persona_ids: z.array(z.coerce.number()).optional(),
 });
 
 /**
@@ -423,30 +427,8 @@ export const QARunEntitySchema = BaseEntitySchema.extend({
   source: z.enum(['manual', 'automation', 'github_pr', 'slack_command']).nullish(),
   source_metadata: z.record(z.string(), z.unknown()).nullish(),
   auto_heal: z.boolean().default(false),
+  auto_accept: z.boolean().default(false),
 });
-
-export const QAVerdictSchema = z.enum(['passed', 'needs_healing', 'failed']);
-export type QAVerdict = z.infer<typeof QAVerdictSchema>;
-
-export const QAEvaluationSchema = z.object({
-  outcome_reached: z.boolean(),
-  steps_aligned: z.boolean(),
-  healing_recommended: z.boolean(),
-  is_actual_bug: z.boolean(),
-  confidence: z.number().min(0).max(1),
-  reasoning: z.string(),
-  evaluated_at: z.string(),
-});
-export type QAEvaluation = z.infer<typeof QAEvaluationSchema>;
-
-export const QATestVerdictEntitySchema = BaseEntitySchema.extend({
-  qa_run_id: z.number(),
-  qa_test_case_id: z.number(),
-  simulation_task_id: z.string().nullable(),
-  verdict: QAVerdictSchema,
-  evaluation: QAEvaluationSchema.nullable(),
-});
-export type QATestVerdictData = z.infer<typeof QATestVerdictEntitySchema>;
 
 /**
  * JSON entry schemas for qa_test_case embedded arrays
@@ -478,6 +460,33 @@ export const QAHealingAttemptEntrySchema = z.object({
   healed_version: z.number().nullish(),
   created_at: z.string(),
 });
+
+/**
+ * QA verdict entity schemas — LLM evaluator output per (qa_run, qa_test_case).
+ * Independent of simulation task status (which keeps raw execution semantics).
+ */
+export const QAVerdictSchema = z.enum(['passed', 'needs_healing', 'failed']);
+export type QAVerdict = z.infer<typeof QAVerdictSchema>;
+
+export const QAEvaluationSchema = z.object({
+  outcome_reached: z.boolean(),
+  steps_aligned: z.boolean(),
+  healing_recommended: z.boolean(),
+  is_actual_bug: z.boolean(),
+  confidence: z.number().min(0).max(1),
+  reasoning: z.string(),
+  evaluated_at: z.string(),
+});
+export type QAEvaluation = z.infer<typeof QAEvaluationSchema>;
+
+export const QATestVerdictEntitySchema = BaseEntitySchema.extend({
+  qa_run_id: z.number(),
+  qa_test_case_id: z.number(),
+  simulation_task_id: z.string().nullable(),
+  verdict: QAVerdictSchema,
+  evaluation: QAEvaluationSchema.nullable(),
+});
+export type QATestVerdictData = z.infer<typeof QATestVerdictEntitySchema>;
 
 /** QA test case entity schema. */
 export const QATestCaseEntitySchema = BaseEntitySchema.extend({
@@ -947,6 +956,7 @@ export const SessionEntitySchema = BaseEntitySchema.extend({
     .object({
       userAgent: z.string().optional(),
       url: z.string().optional(),
+      viewport: z.object({ width: z.number(), height: z.number() }).optional(),
     })
     .nullable(),
   last_batch_index: z.coerce.number().int().nullable(),
@@ -971,6 +981,7 @@ export const SessionUpsertSchema = z.object({
       userAgent: z.string().optional(),
       url: z.string().optional(),
       applicationId: z.number().optional(), // API persists to application_id column; also accepted from metadata
+      viewport: z.object({ width: z.number(), height: z.number() }).optional(),
     })
     .nullable()
     .optional(),
@@ -1895,7 +1906,7 @@ export const GithubWorkflowRunSchema = z.object({
 // AUTOMATION SCHEMAS - DAG-based workflow engine
 // ============================================================================
 
-export const AutomationRunStatusSchema = z.enum(['pending', 'in_progress', 'completed', 'failed', 'stopped']);
+export const AutomationRunStatusSchema = z.enum(['pending', 'running', 'completed', 'failed', 'stopped']);
 
 export const AutomationNodeKindSchema = z.enum(['connector', 'condition']);
 
@@ -2711,10 +2722,19 @@ export const InsightPersonaEntitySchema = z.object({
   application_id: z.number(),
   segment_id: z.number().nullable(),
   segment_name: z.string().optional(),
+  is_selected: z.boolean().default(false),
+  is_top: z.boolean().default(false),
   name: z.string(),
   initials: z.string(),
   description: z.string(),
   traits: z.array(z.string()),
+  tags: z.array(z.string()).optional().default([]),
+  source: z.enum(['generated', 'domain', 'manual']).optional().default('generated'),
+  age_range: z.string().optional().default(''),
+  goals: z.string().optional().default(''),
+  behavior: z.string().optional().default(''),
+  pain_points: z.string().optional().default(''),
+  triggers: z.string().optional().default(''),
   openness: z.number().nullable().optional(),
   conscientiousness: z.number().nullable().optional(),
   extraversion: z.number().nullable().optional(),
@@ -2737,6 +2757,45 @@ export const InsightPersonasResponseSchema = z.object({
   personas: z.array(InsightPersonaEntitySchema),
 });
 
+export const DomainPersonaSuggestionSchema = z.object({
+  name: z.string(),
+  initials: z.string(),
+  description: z.string(),
+  traits: z.array(z.string()),
+  tags: z.array(z.string()).optional().default([]),
+  is_top: z.boolean().default(false),
+});
+
+export const InsightPersonasSaveDomainInputSchema = z.object({
+  personas: z.array(
+    DomainPersonaSuggestionSchema.extend({
+      is_selected: z.boolean(),
+    }),
+  ),
+});
+
+export const InsightPersonaUpdateInputSchema = z.object({
+  id: z.coerce.number(),
+  name: z.string().optional(),
+  description: z.string().optional(),
+  age_range: z.string().optional(),
+  goals: z.string().optional(),
+  behavior: z.string().optional(),
+  pain_points: z.string().optional(),
+  triggers: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  traits: z.array(z.string()).optional(),
+  key_features: z.array(z.string()).optional(),
+});
+
+export const DomainPersonaSuggestResponseSchema = z
+  .object({
+    label: z.string(),
+    industry: z.string(),
+    personas: z.array(DomainPersonaSuggestionSchema),
+  })
+  .nullable();
+
 // Heatmaps
 
 export const HeatmapTypeSchema = z.enum(['clicks', 'scroll', 'attention']);
@@ -2756,6 +2815,13 @@ export const HeatmapStatsSchema = z.object({
   dead_zones: z.number(),
 });
 
+export const HeatmapElementCountSchema = z.object({
+  selector: z.string(),
+  count: z.number(),
+  dead_clicks: z.number(),
+  rage_clicks: z.number(),
+});
+
 export const HeatmapPageEntitySchema = z.object({
   id: z.number(),
   application_id: z.number(),
@@ -2763,6 +2829,9 @@ export const HeatmapPageEntitySchema = z.object({
   session_count: z.number(),
   variation_count: z.number(),
   variations: z.array(HeatmapVariationSchema).default([]),
+  visitor_count: z.number().optional(),
+  last_aggregated_at: z.coerce.date().nullable().optional(),
+  representative_session_id: z.string().nullable().optional(),
 });
 
 export const HeatmapSnapshotEntitySchema = z.object({
@@ -2772,7 +2841,33 @@ export const HeatmapSnapshotEntitySchema = z.object({
   type: HeatmapTypeSchema,
   spots: z.array(HeatSpotSchema),
   stats: HeatmapStatsSchema,
+  page_width: z.number().nullable().optional(),
+  page_height: z.number().nullable().optional(),
+  element_counts: z.array(HeatmapElementCountSchema).optional(),
+  representative_session_override: z.string().nullable().optional(),
 });
+
+export const HeatmapJobStatusSchema = z.object({
+  job_id: z.string().nullable(),
+  status: z.enum(['idle', 'queued', 'active', 'completed', 'failed']),
+  last_aggregated_at: z.coerce.date().nullable(),
+});
+
+/**
+ * Candidate session returned by `insightHeatmapCandidates`. Represents a
+ * session that contributed to a (page, variation) heatmap and could be
+ * pinned as that snapshot's DOM backdrop via `insightHeatmapSetBackdrop`.
+ */
+export const HeatmapCandidateSchema = z.object({
+  session_id: z.string(),
+  width: z.number(),
+  height: z.number(),
+  event_count: z.number(),
+  started_at: z.coerce.date(),
+  has_full_snapshot: z.boolean(),
+});
+
+export type HeatmapCandidate = z.infer<typeof HeatmapCandidateSchema>;
 
 // Reactions
 


### PR DESCRIPTION
## Plan
- Copy `schema.ts` and `routes.ts` from api source-of-truth (post-coerceJsonArray-cleanup commit).
- Re-apply the intentional `Uint8Array` divergence on `fromMulterFile` (widget runs in browser — no Node `Buffer`).

## Verification
- `diff` against api `schema.ts` shows EXACTLY one hunk (`Buffer` → `Uint8Array` on `fromMulterFile`).
- `diff -q` against api `routes.ts` is clean.
- type-check + build pass.

## Coordination
Pairs with api PR (Marketrix-ai/api#TBD) and app PR (Marketrix-ai/app#TBD). Cross-cutting parent: Marketrix-ai/.github#17.

Closes #113
Refs Marketrix-ai/.github#17