### PR TITLE
chore(sdk): resync mirrors after schema-honesty changes

### DIFF
--- a/src/sdk/routes.ts
+++ b/src/sdk/routes.ts
@@ -135,6 +135,7 @@ import {
   SimulationAnswerSchema,
   SimulationCreateSchema,
   SimulationEntitySchema,
+  SimulationListEntitySchema,
   SimulationProgressEntitySchema,
   SimulationStepSchema,
   SimulationStepSummarySchema,
@@ -1583,7 +1584,7 @@ const contract = {
         })
         .extend(PaginationSchema.shape),
     )
-    .output(paginatedListOf(SimulationEntitySchema)),
+    .output(paginatedListOf(SimulationListEntitySchema)),
 
   simulationStart: oc
     .route({
@@ -2219,7 +2220,6 @@ const contract = {
     .output(
       z.object({
         run: QARunEntitySchema,
-        simulations: z.array(SimulationEntitySchema),
       }),
     ),
 

--- a/src/sdk/schema.ts
+++ b/src/sdk/schema.ts
@@ -897,6 +897,17 @@ export const SimulationEntitySchema = BaseEntitySchema.extend({
 });
 
 /**
+ * Simulation row shape returned by list endpoints (e.g. simulationSearch).
+ * Omits per-row fields that are heavy and unused in the list view: `tasks`
+ * (full SimulationTaskEntry array) and `source_metadata` (free-form bag).
+ */
+export const SimulationListEntitySchema = SimulationEntitySchema.omit({
+  tasks: true,
+  source_metadata: true,
+});
+export type SimulationListData = z.infer<typeof SimulationListEntitySchema>;
+
+/**
  * Simulation logging user - user who has started at least one simulation (for GET /simulation/logging-users)
  */
 export const SimulationLoggingUserSchema = z.object({
@@ -910,13 +921,15 @@ export const SimulationLoggingUserSchema = z.object({
 /**
  * Simulation creation schema
  */
-export const SimulationCreateSchema = SimulationEntitySchema.partial().extend({
-  application_id: z.number(),
-  agent_id: z.number(),
-  instructions: z.string(),
-  max_steps: z.number().int().positive().max(1000).optional(),
-  timeout: z.number().positive().max(360).optional(), // Max 6 hours in minutes
-});
+export const SimulationCreateSchema = SimulationEntitySchema.omit({ tasks: true })
+  .partial()
+  .extend({
+    application_id: z.number(),
+    agent_id: z.number(),
+    instructions: z.string(),
+    max_steps: z.number().int().positive().max(1000).optional(),
+    timeout: z.number().positive().max(360).optional(), // Max 6 hours in minutes
+  });
 
 /**
  * Simulation update schema


### PR DESCRIPTION
## Plan

Sync `src/sdk/schema.ts` and `src/sdk/routes.ts` from api source-of-truth after #344. Schema diff against api is exactly one hunk on `fromMulterFile` (Buffer → Uint8Array, intentional divergence — widget runs in browser).

## Verification
- `diff routes.ts`: identical
- `diff schema.ts`: one hunk on `fromMulterFile`
- type-check + build pass

Closes #115
Refs https://github.com/Marketrix-ai/.github/issues/19