### PR TITLE
[Bug Fix] - Omit password field from application API response schemas

### DIFF
--- a/src/sdk/routes.ts
+++ b/src/sdk/routes.ts
@@ -51,7 +51,7 @@ import {
   AppEventSchema,
   AppEventScopeSchema,
   ApplicationCreateSchema,
-  ApplicationEntitySchema,
+  ApplicationReadSchema,
   ApplicationTypeSchema,
   ApplicationUpdateSchema,
   AutomationCreateSchema,
@@ -554,7 +554,7 @@ const contract = {
       description: 'Creates a new application for the authenticated workspace and returns the created entity.',
     })
     .input(ApplicationCreateSchema)
-    .output(ApplicationEntitySchema),
+    .output(ApplicationReadSchema),
 
   applicationSearch: oc
     .route({
@@ -575,7 +575,7 @@ const contract = {
     )
     .output(
       paginatedListOf(
-        ApplicationEntitySchema.extend({
+        ApplicationReadSchema.extend({
           widgets: z.array(WidgetEntitySchema).optional(),
         }),
       ),
@@ -591,7 +591,7 @@ const contract = {
     })
     .input(ByApplicationIdSchema)
     .output(
-      ApplicationEntitySchema.extend({
+      ApplicationReadSchema.extend({
         widgets: z.array(WidgetEntitySchema),
       }),
     ),
@@ -605,7 +605,7 @@ const contract = {
       description: 'Updates application details and configuration',
     })
     .input(ApplicationUpdateSchema.extend({ application_id: z.coerce.number() }))
-    .output(ApplicationEntitySchema),
+    .output(ApplicationReadSchema),
 
   applicationDelete: oc
     .route({

--- a/src/sdk/schema.ts
+++ b/src/sdk/schema.ts
@@ -1273,6 +1273,12 @@ export const ApplicationEntitySchema = BaseEntitySchema.extend({
 });
 
 /**
+ * Application read schema — entity minus password. Used for all API
+ * responses; password is write-only and never returned to clients.
+ */
+export const ApplicationReadSchema = ApplicationEntitySchema.omit({ password: true });
+
+/**
  * Application creation schema
  */
 export const ApplicationCreateSchema = ApplicationEntitySchema.partial().extend({
@@ -1358,7 +1364,7 @@ export const WidgetEntitySchema = BaseEntitySchema.extend({
  * Widget information schema
  */
 export const WidgetInfoSchema = WidgetEntitySchema.extend({
-  application: ApplicationEntitySchema.partial(),
+  application: ApplicationReadSchema.partial(),
   workspace: WorkspaceEntitySchema.partial(),
   user: UserEntitySchema.partial(),
   agent: AgentEntitySchema.partial(),
@@ -1374,7 +1380,7 @@ export const WidgetWithAgentSchema = WidgetEntitySchema.extend({
 /**
  * Application with widgets schema - matches API response structure
  */
-export const ApplicationWithWidgetsSchema = ApplicationEntitySchema.extend({
+export const ApplicationWithWidgetsSchema = ApplicationReadSchema.extend({
   widgets: z.array(WidgetEntitySchema).optional(),
   agents: z.array(AgentEntitySchema).optional(),
 });
@@ -2492,6 +2498,7 @@ export type WorkspacePlanData = z.infer<typeof WorkspacePlanEntitySchema>;
 export type AgentData = z.infer<typeof AgentEntitySchema>;
 export type KnowledgeData = z.infer<typeof KnowledgeEntitySchema>;
 export type ApplicationData = z.infer<typeof ApplicationEntitySchema>;
+export type ApplicationReadData = z.infer<typeof ApplicationReadSchema>;
 export type ApplicationCreateData = z.infer<typeof ApplicationCreateSchema>;
 export type ApplicationUpdateData = z.infer<typeof ApplicationUpdateSchema>;
 export type ApplicationWithWidgetsData = z.infer<typeof ApplicationWithWidgetsSchema>;


### PR DESCRIPTION
## Summary
This PR implements a security hardening measure by ensuring that sensitive application passwords are never exposed through the API response payloads. 

Previously, the `ApplicationEntitySchema` was used for both database representation and API outputs, which included the `password` field. I have introduced `ApplicationReadSchema`, which explicitly omits the `password` field from the base entity. All relevant routes (create, search, get, update) and nested schemas (widgets, info) have been updated to use this new read-only schema for outputs.

## Related issue
<!-- Use Closes/Fixes/Resolves to link. project-sync moves the linked issue to In Progress. -->
<!-- Closes # -->

## Test plan
- [ ] Verify via API client that `POST /applications`, `GET /applications`, and `PATCH /applications` responses no longer contain the `password` key.
- [ ] Run `npm run type-check` to ensure all dependent services correctly handle the updated schema types.
- [ ] Validate that nested structures (e.g., `WidgetInfoSchema`) also exclude the password field.

## Checklist
- [x] CI passes (type-check + lint)
- [x] Shared contracts in sync if changed (`routes.ts`, `schema.ts`, `proto`)