### PR TITLE
Wave 5 sync stateTrigger — widget SDK mirror

### DIFF
--- a/src/sdk/routes.ts
+++ b/src/sdk/routes.ts
@@ -144,6 +144,9 @@ import {
   SlackCommandLogEntitySchema,
   SlackCommandLogSearchSchema,
   SlackSettingsDataSchema,
+  StateTriggerCreateSchema,
+  StateTriggerEntitySchema,
+  StateTriggerUpdateSchema,
   StripeCheckoutSchema,
   StripeConfigSchema,
   StripeDowngradeResponseSchema,
@@ -160,9 +163,6 @@ import {
   TriggerEntitySchema,
   TriggerSearchSchema,
   TriggerUpdateSchema,
-  UrlGuideCreateSchema,
-  UrlGuideEntitySchema,
-  UrlGuideUpdateSchema,
   UserEntitySchema,
   UserQuotaSchema,
   UserUpdateSchema,
@@ -1458,71 +1458,71 @@ const contract = {
     .output(paginatedListOf(ActionLogEntitySchema)),
 
   // ============================================================================
-  // URL GUIDE ROUTES - URL-based guidance messages for widget
+  // STATE TRIGGER ROUTES - URL-based guidance messages for widget
   // ============================================================================
 
-  urlGuideSearch: oc
+  stateTriggerSearch: oc
     .route({
       method: 'GET',
-      tags: ['URL Guide'],
+      tags: ['State Trigger'],
       path: '/url-guide',
-      summary: 'Search URL guides by widget',
-      description: 'Returns list of URL guides for specified widget',
+      summary: 'Search state triggers by widget',
+      description: 'Returns list of state triggers for specified widget',
     })
     .input(ByWidgetIdSchema.extend(PaginationSchema.shape))
-    .output(paginatedListOf(UrlGuideEntitySchema)),
+    .output(paginatedListOf(StateTriggerEntitySchema)),
 
-  urlGuideCreate: oc
+  stateTriggerCreate: oc
     .route({
       method: 'POST',
-      tags: ['URL Guide'],
+      tags: ['State Trigger'],
       path: '/url-guide',
-      summary: 'Create new URL guide',
-      description: 'Creates URL guide with pattern and message',
+      summary: 'Create new state trigger',
+      description: 'Creates state trigger with pattern and message',
     })
-    .input(UrlGuideCreateSchema)
-    .output(UrlGuideEntitySchema),
+    .input(StateTriggerCreateSchema)
+    .output(StateTriggerEntitySchema),
 
-  urlGuideGet: oc
+  stateTriggerGet: oc
     .route({
       method: 'GET',
-      tags: ['URL Guide'],
+      tags: ['State Trigger'],
       path: '/url-guide/{id}',
-      summary: 'Get URL guide by ID',
-      description: 'Returns URL guide details',
+      summary: 'Get state trigger by ID',
+      description: 'Returns state trigger details',
     })
     .input(ByIdSchema)
-    .output(UrlGuideEntitySchema),
+    .output(StateTriggerEntitySchema),
 
-  urlGuideUpdate: oc
+  stateTriggerUpdate: oc
     .route({
       method: 'PUT',
-      tags: ['URL Guide'],
+      tags: ['State Trigger'],
       path: '/url-guide/{id}',
-      summary: 'Update URL guide',
-      description: 'Updates URL guide properties',
+      summary: 'Update state trigger',
+      description: 'Updates state trigger properties',
     })
-    .input(UrlGuideUpdateSchema.extend({ id: z.coerce.number() }))
-    .output(UrlGuideEntitySchema),
+    .input(StateTriggerUpdateSchema.extend({ id: z.coerce.number() }))
+    .output(StateTriggerEntitySchema),
 
-  urlGuideDelete: oc
+  stateTriggerDelete: oc
     .route({
       method: 'DELETE',
-      tags: ['URL Guide'],
+      tags: ['State Trigger'],
       path: '/url-guide/{id}',
-      summary: 'Delete URL guide',
-      description: 'Permanently deletes a URL guide. This action cannot be undone.',
+      summary: 'Delete state trigger',
+      description: 'Permanently deletes a state trigger. This action cannot be undone.',
     })
     .input(ByIdSchema)
     .output(SuccessSchema),
 
-  urlGuideMatch: oc
+  stateTriggerMatch: oc
     .route({
       method: 'GET',
-      tags: ['URL Guide'],
+      tags: ['State Trigger'],
       path: '/url-guide/match',
-      summary: 'Find matching URL guide for current URL',
-      description: 'Returns matching URL guide for a given URL pattern',
+      summary: 'Find matching state trigger for current URL',
+      description: 'Returns matching state trigger for a given URL pattern',
     })
     .input(
       z.object({
@@ -1530,7 +1530,7 @@ const contract = {
         url: z.string(),
       }),
     )
-    .output(UrlGuideEntitySchema.nullable()),
+    .output(StateTriggerEntitySchema.nullable()),
 
   // ============================================================================
   // SIMULATION ROUTES - Application simulation and testing

--- a/src/sdk/schema.ts
+++ b/src/sdk/schema.ts
@@ -1395,14 +1395,14 @@ export const WidgetCreateSchema = WidgetEntitySchema.partial().extend({
 export const WidgetUpdateSchema = WidgetEntitySchema.partial();
 
 // ============================================================================
-// URL GUIDE SCHEMAS - URL-based guidance messages for widget
+// STATE TRIGGER SCHEMAS - URL-based guidance messages for widget
 // ============================================================================
 
 /**
- * URL Guide entity schema - stores URL patterns and messages to show in widget
+ * State Trigger entity schema - stores URL patterns and messages to show in widget
  * message can be a string (single message) or array of strings (multiple chips)
  */
-export const UrlGuideEntitySchema = BaseEntitySchema.extend({
+export const StateTriggerEntitySchema = BaseEntitySchema.extend({
   widget_id: z.number(),
   url_pattern: z.string(),
   message: z.union([z.string(), z.array(z.string())]), // Support both single message and multiple messages
@@ -1410,18 +1410,18 @@ export const UrlGuideEntitySchema = BaseEntitySchema.extend({
 });
 
 /**
- * URL Guide creation schema
+ * State Trigger creation schema
  */
-export const UrlGuideCreateSchema = UrlGuideEntitySchema.partial().extend({
+export const StateTriggerCreateSchema = StateTriggerEntitySchema.partial().extend({
   widget_id: z.number().positive(),
   url_pattern: z.string().min(1),
   message: z.union([z.string().min(1), z.array(z.string().min(1)).min(1)]), // Support both single message and multiple messages
 });
 
 /**
- * URL Guide update schema
+ * State Trigger update schema
  */
-export const UrlGuideUpdateSchema = UrlGuideEntitySchema.partial();
+export const StateTriggerUpdateSchema = StateTriggerEntitySchema.partial();
 
 // ============================================================================
 // CHAT SCHEMAS - AI-powered chat and conversation management
@@ -2499,9 +2499,9 @@ export type WidgetData = z.infer<typeof WidgetEntitySchema>;
 export type WidgetWithAgentData = z.infer<typeof WidgetWithAgentSchema>;
 export type WidgetCreateData = z.infer<typeof WidgetCreateSchema>;
 export type WidgetUpdateData = z.infer<typeof WidgetUpdateSchema>;
-export type UrlGuideData = z.infer<typeof UrlGuideEntitySchema>;
-export type UrlGuideCreateData = z.infer<typeof UrlGuideCreateSchema>;
-export type UrlGuideUpdateData = z.infer<typeof UrlGuideUpdateSchema>;
+export type StateTriggerData = z.infer<typeof StateTriggerEntitySchema>;
+export type StateTriggerCreateData = z.infer<typeof StateTriggerCreateSchema>;
+export type StateTriggerUpdateData = z.infer<typeof StateTriggerUpdateSchema>;
 export type WidgetSettingsData = z.infer<typeof WidgetSettingsDataSchema>;
 export type SlackSettingsData = z.infer<typeof SlackSettingsDataSchema>;
 export type WidgetSettingsKey = keyof z.infer<typeof WidgetSettingsDataSchema>;


### PR DESCRIPTION
Closes #122

## Summary

Part 3 of `urlGuide → stateTrigger` rename: SDK mirror sync from api source of truth (api v3.3.143).

Widget itself does not consume the renamed admin routes (these are dashboard routes), so this is mechanical mirror sync only.

## Changes

- `src/sdk/routes.ts` refreshed from api/routes.ts
- `src/sdk/schema.ts` refreshed from api/schema.ts (preserving F-078 intentional Buffer→Uint8Array drift in fromMulterFile)

## Findings addressed

- **F-085** (widget portion) — SDK mirror urlGuide* names
- **F-105** (widget portion) — SDK mirror extended remnants

## Coordination

Depends on: api PR #362 (merged at api v3.3.143).
Companion: app PR #483 — SDK mirror + toast strings + JSX.

## Verification

- [x] `npm run code:check` — green
- [x] `npm run test:run` (vitest) — green (160 passed)
- [x] `npm run build` (vite) — green
- [x] Lockfile unchanged
- [x] F-078 drift preserved (Buffer→Uint8Array in fromMulterFile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)