### PR TITLE
Wave 4 declare @rrweb/types as explicit devDep (F-095)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@rrweb/types": "^2.0.0-alpha.20",
         "@tailwindcss/vite": "^4.2.4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -1121,6 +1122,8 @@
     },
     "node_modules/@rrweb/types": {
       "version": "2.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.0.0-alpha.20.tgz",
+      "integrity": "sha512-RbnDgKxA/odwB1R4gF7eUUj+rdSrq6ROQJsnMw7MIsGzlbSYvJeZN8YY4XqU0G6sKJvXI6bSzk7w/G94jNwzhw==",
       "license": "MIT"
     },
     "node_modules/@rrweb/utils": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@rrweb/types": "^2.0.0-alpha.20",
     "@tailwindcss/vite": "^4.2.4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",


### PR DESCRIPTION
Closes #124

## Summary

Adds `@rrweb/types` to `devDependencies` so the import in `SessionRecorder.ts` doesn't depend on transitive resolution via `@rrweb/record`.

## Verification

- [x] `npm run code:check` — green
- [x] `npm run test:run` (vitest) — green
- [x] `npm run build` (vite) — green
- [x] Lockfile committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)