### PR TITLE
Wave 6 surface ChatService init failure — widget (F-079)

### DIFF
--- a/src/context/WidgetProviders.tsx
+++ b/src/context/WidgetProviders.tsx
@@ -40,6 +40,12 @@ const WidgetContextBridge: React.FC<BridgeProps> = ({ children, previewMode }) =
     const init = async () => {
       const chatId = await sessionManager.getOrCreateChatId();
       chatService.createInitialContext(chatId);
+
+      const initErr = chatService.getInitError();
+      if (initErr) {
+        uiActions.setError('Widget failed to initialise — please refresh the page.');
+      }
+
       chatService.initialize(chatId);
 
       const isTaskRunning = chatService.getIsTaskRunning();

--- a/src/services/ChatService.ts
+++ b/src/services/ChatService.ts
@@ -13,6 +13,7 @@ export class ChatService {
   private isOpen: boolean = false;
   private isMinimized: boolean = false;
   private isLoading: boolean = false;
+  initError: Error | null = null;
 
   private constructor() {}
 
@@ -48,7 +49,12 @@ export class ChatService {
       });
     } catch (error) {
       console.error('[ChatService] Failed to create initial chat context:', error);
+      this.initError = error instanceof Error ? error : new Error(String(error));
     }
+  }
+
+  getInitError(): Error | null {
+    return this.initError;
   }
 
   getMessages(): ChatMessage[] {


### PR DESCRIPTION
Closes #126

## Summary

- `ChatService.createInitialContext()` was swallowing `storageService` failures, leaving the service in an uninitialised state with no user-visible signal.
- Added `initError: Error | null` field (public) and `getInitError()` getter on `ChatService`.
- The catch block now sets `initError` in addition to the existing `console.error`.
- `WidgetContextBridge.init()` in `WidgetProviders.tsx` checks `getInitError()` immediately after `createInitialContext()` and calls `uiActions.setError()` to surface a user-visible message via the existing `UIState.error` field.

## Verification

- [x] `npm run code:check` — green
- [x] `npm run test:run` (vitest — 160 tests) — green
- [x] `npm run build` (vite) — green
- [x] Lockfile unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)