### PR TITLE
Wave 13: Dedupe Flex/Surface + canonicalize StorageService (F-046, F-048)

### DIFF
--- a/src/components/base/Flex.tsx
+++ b/src/components/base/Flex.tsx
@@ -2,51 +2,23 @@ import { forwardRef, type ReactNode } from 'react';
 
 import { cn } from '@/lib/utils';
 
-import { getElevationStyle, type RadiusToken } from '../../design-system/component-tokens';
-import type { ShadowToken } from '../../design-system/shadows';
-import { type LayoutProps, resolveLayoutClasses, stripLayoutProps } from './layoutProps';
-import { backgroundClasses, paddingPresetClasses, type SurfaceBackground, type SurfacePadding } from './Surface';
+import { Surface, type SurfaceProps } from './Surface';
 
-export interface FlexProps extends LayoutProps, Omit<React.HTMLAttributes<HTMLElement>, 'className'> {
-  background?: SurfaceBackground;
+/**
+ * Flex extends Surface with flexbox semantics.
+ *
+ * Composes `Surface` so that the prop-forwarding, className merging, and
+ * elevation/padding/background/radius/layout handling all live in exactly
+ * one place. Flex's only contribution is the `flex` utility class plus an
+ * optional `flex-col` from the `direction` prop. Public API is unchanged
+ * for callers.
+ */
+export interface FlexProps extends SurfaceProps {
   direction?: 'row' | 'column';
-  elevation?: ShadowToken;
-  paddingPreset?: SurfacePadding;
-  radius?: RadiusToken;
-  /** @internal blocks/ only */
-  className?: string;
   children?: ReactNode;
 }
 
 export const Flex = forwardRef<HTMLElement, FlexProps>(function Flex(props, ref) {
-  const {
-    as: Component = 'div',
-    background = 'default',
-    direction,
-    className,
-    elevation,
-    paddingPreset = 'none',
-    radius,
-    style,
-    ...rest
-  } = props;
-  const layoutClasses = resolveLayoutClasses(props);
-  const domProps = stripLayoutProps(rest);
-
-  return (
-    <Component
-      {...domProps}
-      ref={ref}
-      className={cn(
-        'flex',
-        direction === 'column' && 'flex-col',
-        backgroundClasses[background],
-        paddingPresetClasses[paddingPreset],
-        radius && resolveLayoutClasses({ rounded: radius }),
-        layoutClasses,
-        className,
-      )}
-      style={{ ...getElevationStyle(elevation), ...style }}
-    />
-  );
+  const { className, direction, ...rest } = props;
+  return <Surface {...rest} ref={ref} className={cn('flex', direction === 'column' && 'flex-col', className)} />;
 });

--- a/src/services/StorageService.ts
+++ b/src/services/StorageService.ts
@@ -3,6 +3,17 @@
  *
  * Consolidates all widget localStorage into a single key: marketrix_chat_context
  * Contains: chat_id, messages, widget state, and config
+ *
+ * **Canonical implementation.** This file is the source of truth for the
+ * `StorageService` mirror pair. The matching `app/src/services/StorageService.ts`
+ * in the dashboard repo should be byte-identical to this file (modulo its
+ * own `'../types'` import path). When updating storage semantics, change
+ * this file first and copy the result over to the app mirror.
+ *
+ * Why widget is canonical: the chat context object (chat_id, messages,
+ * task progress, widget config) originates in the embeddable widget — the
+ * widget owns the read/write lifecycle, and the dashboard only ever reads
+ * the same shape for parity. See Wave 13 cleanup (F-048).
  */
 
 import type { ChatMessage, InstructionType, MarketrixConfig, TaskProgress } from '../types';
@@ -56,6 +67,12 @@ const DEFAULT_CONTEXT: MarketrixChatContext = {
   timestamp: Date.now(),
 };
 
+/**
+ * Singleton wrapper around `localStorage` for the unified widget chat context.
+ *
+ * Canonical implementation — see file header. Mirror in `app/src/services/StorageService.ts`
+ * must be byte-identical (modulo the relative path of the `../types` import).
+ */
 class StorageService {
   private static instance: StorageService;
   private context: MarketrixChatContext | null = null;


### PR DESCRIPTION
Closes #132

## Summary

Wave 13 widget cleanup, two adjacent audit findings:

- **F-046 — Flex/Surface dedup.** The 28-line clone between `Flex` and `Surface` is gone. `Flex` now composes `Surface` and contributes only the `flex` utility class plus an optional `flex-col` from `direction`. All prop-forwarding, className merging, and elevation/padding/background/radius/layout handling lives in `Surface` alone. Public API of both components is unchanged for callers.
- **F-048 — StorageService canonical version.** Widget's `StorageService` is now explicitly declared the canonical implementation of the app/widget mirror pair, via JSDoc on both the file header and the class declaration. No behavior changes — this is just documentation that the upcoming Wave 13 app-side PR will copy this exact implementation into `app/src/services/StorageService.ts`.

## Plan vs implementation

Plan called for: pick compose vs extract-base for Flex/Surface, then a JSDoc clarification pass on StorageService. **Approach taken:** compose. Flex IS-A Surface with extra styling (`flex` + optional `flex-col`), so wrapping `Surface` is the cleanest expression of the relationship — no new abstraction layer, and `Surface`'s tests cover the underlying behavior. `Stack` was left untouched (it's a separate clone of the same shape, but tightening it up is out of scope for the F-046 audit finding and would have widened the PR for marginal benefit).

For F-048: only documentation was added — no stale comments or dead code were found in widget's `StorageService`, so no behavior-touching cleanup was needed.

## Files changed

- `src/components/base/Flex.tsx` — refactored to compose `Surface`, added JSDoc explaining the relationship
- `src/services/StorageService.ts` — added canonical-implementation JSDoc on the file header and the class declaration

## LOC delta

`+30 / -41` (net `-11` lines), entirely from Flex shrinking from 53 lines to 24 while StorageService gained 17 lines of pure JSDoc.

## Test plan

- [x] `npm run code:check` (tsc + eslint + prettier) — green
- [x] `npm run test:run` — 187/187 tests pass (17 test files)
- [x] `npm run build` — vite build green, TS declarations generated
- [x] Public API of `Flex` (and `Surface` and `Stack`) unchanged — all consumers in `blocks/`, `chat/`, `views/`, `navigation/`, `ui/` continue to compile and pass tests without modification
- [x] `StorageService` behavior unchanged — only JSDoc added; the existing `StorageService` test suite passes

## Guardrails honored

- No visual or behavioral change to Flex/Surface output (twMerge resolution order preserved — user `className` still wins last)
- No change to `StorageService` semantics — same singleton load timing, expiry window, null-check behavior
- SDK sync files (Wave 8a/9b artifacts in `src/sdk/`) untouched
- No dependency, lockfile, or version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)