### PR TITLE
Wave 14: WidgetEventSchema cutover — 'started' → 'running' (BREAKING)

### DIFF
--- a/src/context/TaskContext.tsx
+++ b/src/context/TaskContext.tsx
@@ -290,7 +290,10 @@ export const TaskProvider: React.FC<TaskProviderProps> = ({
         const status = event.status;
         const statusMessage = event.message || '';
 
-        if (status === 'started') {
+        if (status === 'running') {
+          // Wave 14 (C1 cutover): legacy `'started'` was renamed to canonical
+          // `'running'` here. Internal widget enums for tool-call progress
+          // remain `'in_progress'`/`'completed'`/`'failed'` (separate concept).
           pendingTaskRef.current = {
             ...pendingTaskRef.current,
             agentStarted: true,

--- a/src/sdk/schema.ts
+++ b/src/sdk/schema.ts
@@ -884,7 +884,10 @@ export const SimulationTaskEntrySchema = z.object({
   task_id: z.string(),
   title: z.string(),
   instructions: z.string(),
-  status: z.enum(['pending', 'in_progress', 'has_question', 'passed', 'failed', 'skipped', 'stopped']),
+  // Wave 14 (B1 cleanup): writers now use 'running' instead of 'in_progress'.
+  // 'in_progress' is retained for backward compat with old JSONB rows; readers
+  // may still encounter it. New writes always use 'running'.
+  status: z.enum(['pending', 'running', 'in_progress', 'has_question', 'passed', 'failed', 'skipped', 'stopped']),
   error_message: z.string().nullish(),
   started_at: z.string().nullish(),
   completed_at: z.string().nullish(),
@@ -1498,7 +1501,11 @@ export const WidgetEventSchema = z.discriminatedUnion('type', [
   }),
   z.object({
     type: z.literal('task/status'),
-    status: z.enum(['started', 'completed', 'failed', 'stopped', 'in_progress', 'has_question']),
+    // Wave 14 (C1 cutover): canonical wire vocabulary. Legacy `'started'` and
+    // `'in_progress'` were dropped in this wave — widget now emits `'running'`
+    // for in-progress task events, matching SimulationTaskStatus / QATaskStatus.
+    // BREAKING CHANGE for external widget consumers — bumped in widget v3.3.160.
+    status: z.enum(['running', 'completed', 'failed', 'stopped', 'has_question']),
     message: z.string().optional(),
     task_id: z.string().optional(),
     timestamp: z.number().optional(),
@@ -1564,27 +1571,25 @@ export const AppEventScopeSchema = z.enum(['simulations', 'agents', 'qa', 'user'
  * Simulation status — the contract value emitted by the API on
  * `simulation/updated` events and returned in oRPC simulation payloads.
  *
- * Wave 8a adds `'running'` to the union as the new wire vocabulary. The
- * legacy `'in_progress'` value is retained for backward compat with any
- * historical events still in flight; egress sites translate
- * `'in_progress'` → `'running'` via `internalToWireSimulationStatus()` so
- * consumers see the new wire vocab. The other legacy values
- * (`'pending'`, `'dispatched'`, `'task_stopped'`, `'creating_knowledge'`)
- * remain on this union because the api still emits them today; narrowing
- * is a follow-up beyond Wave 8a's scope.
+ * Wave 14 narrows this union to the canonical 7-value wire vocabulary
+ * matching the SimulationStatus proto enum. Legacy strings (`'pending'`,
+ * `'dispatched'`, `'in_progress'`, `'task_stopped'`) have been migrated to
+ * canonical values at all api writers (see db-V37 migration + A2 cleanup),
+ * so they no longer appear on the wire and have been removed from this
+ * union.
+ *
+ * The two new first-class states (`'creating_knowledge'`, `'has_question'`)
+ * carry through to consumers — the app accepts them in `SimulationStatusSchema`
+ * mirrors.
  */
 export const SimulationStatusSchema = z.enum([
   'queued',
-  'dispatched',
-  'pending',
   'running',
-  'in_progress',
+  'creating_knowledge',
+  'has_question',
   'completed',
   'failed',
   'stopped',
-  'task_stopped',
-  'has_question',
-  'creating_knowledge',
 ]);
 export type SimulationStatus = z.infer<typeof SimulationStatusSchema>;
 
@@ -1593,13 +1598,11 @@ export type SimulationStatus = z.infer<typeof SimulationStatusSchema>;
  * task states. Emitted by the API on `qa-run/updated` events and returned
  * in QA run oRPC payloads.
  *
- * Wave 8a adds `'running'` to the union as the new wire vocabulary.
- * `'in_progress'` is retained for backward compat with any historical
- * events still in flight; egress sites translate `'in_progress'` →
- * `'running'` via `internalToWireQARunStatus()` so consumers see the new
- * wire vocab.
+ * Wave 14 drops `'in_progress'` from the union — `deriveQARunStats` now
+ * returns `'running'` directly (B1 internal cleanup). `'pending'` is kept
+ * as the empty-task initial state.
  */
-export const QARunDerivedStatusSchema = z.enum(['pending', 'running', 'in_progress', 'completed', 'failed', 'stopped']);
+export const QARunDerivedStatusSchema = z.enum(['pending', 'running', 'completed', 'failed', 'stopped']);
 export type QARunDerivedStatus = z.infer<typeof QARunDerivedStatusSchema>;
 
 export const AppEventSchema = z.discriminatedUnion('type', [
@@ -2428,12 +2431,19 @@ export const PlanCatalogEntrySchema = z.object({
   checkColor: z.string(),
 });
 
+/** Inferred type for a single plan catalog entry — mirrored to the app SDK so
+ *  consumers don't need to redeclare the shape locally. */
+export type PlanCatalogEntry = z.infer<typeof PlanCatalogEntrySchema>;
+
 /**
  * Plan catalog response schema (GET /stripe/plans)
  */
 export const PlanCatalogSchema = z.object({
   plans: z.array(PlanCatalogEntrySchema),
 });
+
+/** Inferred type for the plan catalog response. */
+export type PlanCatalog = z.infer<typeof PlanCatalogSchema>;
 
 /**
  * Stripe configuration schema for frontend

--- a/src/services/__tests__/sse-event-handling.test.ts
+++ b/src/services/__tests__/sse-event-handling.test.ts
@@ -21,9 +21,13 @@
  * (`SimulationTaskStatus` / `QATaskStatus`), but `WidgetEventSchema.task/status`
  * was deliberately left on the legacy widget enum (`'started' | 'in_progress' |
  * 'completed' | 'failed' | 'stopped' | 'has_question'`) since chat sessions
- * still emit those values to widget clients in flight. The widget-facing
- * task/status vocabulary cutover is a future wave; these assertions remain
- * pinned to the current WidgetEventSchema shape.
+ * still emit those values to widget clients in flight.
+ *
+ * Wave 14 (C1 cutover) — applied here: the widget event surface aligned with
+ * the canonical wire vocabulary. `'started'` and `'in_progress'` were dropped
+ * from `WidgetEventSchema.task/status`; the union is now
+ * `'running' | 'completed' | 'failed' | 'stopped' | 'has_question'`.
+ * BREAKING CHANGE for external widget consumers — published in v3.3.160.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -50,7 +54,7 @@ const MINIMAL_EVENT_FIXTURES: Record<ExpectedEventType, object> = {
   heartbeat: { type: 'heartbeat' },
   'chat/response': { type: 'chat/response', request_id: 'req-1', text: 'Hello!' },
   'chat/error': { type: 'chat/error', request_id: 'req-2', error: 'Something went wrong' },
-  'task/status': { type: 'task/status', status: 'started' },
+  'task/status': { type: 'task/status', status: 'running' },
   'tool/call': {
     type: 'tool/call',
     call_id: 'call-1',
@@ -77,7 +81,7 @@ describe('SSE event discriminated-union contract (WidgetEventSchema)', () => {
 
   describe('discriminant field "type" is mandatory on every event', () => {
     it('rejects an event with no type field', () => {
-      const result = WidgetEventSchema.safeParse({ status: 'started' });
+      const result = WidgetEventSchema.safeParse({ status: 'running' });
       expect(result.success).toBe(false);
     });
 
@@ -131,8 +135,23 @@ describe('SSE event discriminated-union contract (WidgetEventSchema)', () => {
       expect(WidgetEventSchema.safeParse({ type: 'task/status' }).success).toBe(false);
     });
 
-    it('"started" is a valid status (widget-specific — api uses "in_progress")', () => {
+    it('"running" is a valid status (Wave 14 canonical wire vocab)', () => {
+      const result = WidgetEventSchema.safeParse({ type: 'task/status', status: 'running' });
+      expect(result.success).toBe(true);
+    });
+
+    it('legacy "started" is REJECTED post-Wave-14 (BREAKING contract change)', () => {
       const result = WidgetEventSchema.safeParse({ type: 'task/status', status: 'started' });
+      expect(result.success).toBe(false);
+    });
+
+    it('legacy "in_progress" is REJECTED post-Wave-14 (BREAKING contract change)', () => {
+      const result = WidgetEventSchema.safeParse({ type: 'task/status', status: 'in_progress' });
+      expect(result.success).toBe(false);
+    });
+
+    it('"has_question" remains a valid status (sim-only state propagated to widget)', () => {
+      const result = WidgetEventSchema.safeParse({ type: 'task/status', status: 'has_question' });
       expect(result.success).toBe(true);
     });
 

--- a/src/services/__tests__/widget-status-mapping.test.ts
+++ b/src/services/__tests__/widget-status-mapping.test.ts
@@ -1,27 +1,34 @@
 /**
- * Wave 8a: characterization for widget task status strings (post-schema-split).
+ * Wave 14 (C1 cutover): widget task status now matches the canonical wire
+ * vocabulary. Pre-Wave-14 the widget event surface still emitted the legacy
+ * `'started'` / `'in_progress'` strings; Wave 14 drops them and aligns the
+ * widget's `task/status` discriminator with `SimulationTaskStatus` /
+ * `QATaskStatus` (specifically: `'running'` replaces `'started'`, and
+ * `'in_progress'` is removed).
  *
  * Pre-Wave-8a: widget had its own task status set ('started', 'completed', 'failed', 'stopped').
- * Wave 8a: the api now exposes two distinct wire vocabularies for downstream
- * consumers — sim tasks emit `SimulationTaskStatus` strings, QA tasks emit
- * `QATaskStatus` strings. These tests pin the new wire vocabularies the widget
- * is expected to align with as it consumes upstream events.
+ * Wave 8a: api split sims/QA into two distinct wire vocabularies — sim tasks
+ *   emit `SimulationTaskStatus`, QA tasks emit `QATaskStatus`. The widget event
+ *   surface was deliberately left on the legacy enum at that time.
+ * Wave 14 (C1): widget event surface aligns with the canonical wire vocab —
+ *   `'started'` and `'in_progress'` are dropped from `WidgetEventSchema`.
  *
- * 'started' is replaced by 'running'. 'has_question' (sim only) and
- * 'passed' / 'needs_healing' (QA only) are now valid wire values.
+ * `'has_question'` (sim only) and `'passed'` / `'needs_healing'` (QA only) remain
+ * valid wire values per their respective enums.
  *
- * NOTE: WidgetEventSchema's `task/status` discriminator currently still
- * carries the legacy widget-side enum (api PR #374 deliberately left it
- * untouched for backward compat with chat clients in flight). The Wave 8a
- * cutover for the widget event surface is tracked separately; these
- * assertions characterize the wire vocabulary the widget will adopt.
+ * BREAKING CHANGE for external widget consumers — published in widget v3.3.160.
  */
 import { describe, expect, it } from 'vitest';
 
-describe('Widget task status contract — Wave 8a', () => {
+import { WidgetEventSchema } from '@/sdk/schema';
+
+describe('Widget task status contract — Wave 14 (C1 cutover)', () => {
   const SIM_TASK_STATUSES = ['queued', 'running', 'completed', 'failed', 'has_question', 'stopped'] as const;
 
   const QA_TASK_STATUSES = ['queued', 'running', 'passed', 'failed', 'needs_healing', 'stopped'] as const;
+
+  // Canonical post-Wave-14 set carried by WidgetEventSchema.task/status.
+  const WIDGET_TASK_STATUSES = ['running', 'completed', 'failed', 'stopped', 'has_question'] as const;
 
   it('sim task statuses include all 6 expected values', () => {
     expect(SIM_TASK_STATUSES.length).toBe(6);
@@ -46,5 +53,41 @@ describe('Widget task status contract — Wave 8a', () => {
 
   it('QA task does not have "has_question" (sim-only)', () => {
     expect(QA_TASK_STATUSES as readonly string[]).not.toContain('has_question');
+  });
+
+  // Wave 14 (C1): widget event-surface vocabulary alignment.
+  describe('widget event surface (WidgetEventSchema.task/status)', () => {
+    it('post-Wave-14 union has exactly 5 values', () => {
+      expect(WIDGET_TASK_STATUSES.length).toBe(5);
+    });
+
+    it('"running" replaces legacy "started"', () => {
+      expect(WIDGET_TASK_STATUSES).toContain('running');
+      expect(WIDGET_TASK_STATUSES as readonly string[]).not.toContain('started');
+    });
+
+    it('"in_progress" is no longer a valid widget task status', () => {
+      expect(WIDGET_TASK_STATUSES as readonly string[]).not.toContain('in_progress');
+    });
+
+    it.each(WIDGET_TASK_STATUSES)('schema accepts "%s" as a valid task/status', status => {
+      const result = WidgetEventSchema.safeParse({ type: 'task/status', status });
+      expect(
+        result.success,
+        `expected status="${status}" to be accepted; errors: ${
+          !result.success ? JSON.stringify(result.error.issues) : 'none'
+        }`,
+      ).toBe(true);
+    });
+
+    it('schema REJECTS legacy "started" (Wave 14 contract change)', () => {
+      const result = WidgetEventSchema.safeParse({ type: 'task/status', status: 'started' });
+      expect(result.success).toBe(false);
+    });
+
+    it('schema REJECTS legacy "in_progress" (Wave 14 contract change)', () => {
+      const result = WidgetEventSchema.safeParse({ type: 'task/status', status: 'in_progress' });
+      expect(result.success).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
Closes #134. Fourth and final PR closing Wave 8a deferrals.

## Summary

Aligns the widget chat-side task event vocabulary with the canonical wire vocabulary established by api PR #392 (Wave 14, A2/B1 cleanup):

- `WidgetEventSchema.task/status` union: drop `'started'` and `'in_progress'`, settle on `'running'` / `'completed'` / `'failed'` / `'stopped'` / `'has_question'`.
- `TaskContext.tsx` consumer now switches on `'running'`. Internal tool-call progress enums (`'in_progress'` / `'completed'` / `'failed'`) are a separate concept and remain unchanged.
- Wave 7.5 contract-pin tests updated to assert new union AND explicitly reject legacy `'started'` and `'in_progress'` at the schema boundary.
- CLAUDE.md status table updated at the workspace level (separate workspace-level edit, not part of this widget repo PR) to reflect post-Wave-14 canonical vocabulary.

## BREAKING CHANGE — Customer-facing contract change

Widget npm package `@marketrix.ai/widget` will publish v3.3.160 with this cutover. **Any external consumer of the widget npm package switching on `'started'` will need to update to `'running'`.** Per user direction (locked-in 2026-05-03), this is a clean cutover with no backward compat — `'started'` and `'in_progress'` are now actively REJECTED by the schema.

## References

- Design: `.claude/plans/2026-05-03-wave14-8a-deferrals-design.md`
- api PR #392 (merged): Wave 14 SimulationStatus expansion + db-V37 + A2/B1 cleanup
- User direction: C1 — clean cutover (no dual emission, no backward compat)

## Files changed

- `src/sdk/routes.ts` — synced byte-identical from `api/routes.ts`
- `src/sdk/schema.ts` — synced from `api/schema.ts` + C1 cutover applied to `WidgetEventSchema.task/status`
- `src/context/TaskContext.tsx` — `'started'` → `'running'`
- `src/services/__tests__/widget-status-mapping.test.ts` — Wave 14 pin (5-value union) + rejection assertions for legacy values
- `src/services/__tests__/sse-event-handling.test.ts` — updated fixture + rejection assertions + `'has_question'` acceptance

## F-078 drift status

This PR temporarily introduces F-078 drift on a single line: `api/schema.ts` still carries the legacy `WidgetEventSchema.task/status` union (`['started', 'completed', 'failed', 'stopped', 'in_progress', 'has_question']`), while widget now has the canonical post-Wave-14 union (`['running', 'completed', 'failed', 'stopped', 'has_question']`). All other lines remain byte-identical. **Follow-up: an api sync PR copies the cutover back to the api source-of-truth to restore the byte-identical invariant.**

`src/sdk/routes.ts` is byte-identical to `api/routes.ts`.

## Test plan

- [x] `npm run code:check` green
- [x] `npm run test:run` — 200/200 passing
- [x] `npm run build` green
- [x] Schema rejects legacy `'started'` (regression assertion present)
- [x] Schema rejects legacy `'in_progress'` (regression assertion present)
- [x] `TaskContext` consumer updated to canonical `'running'`
- [ ] Visual smoke test in dev (after merge + v3.3.160 publish + app dependency bump)

## Release coordination

Per CLAUDE.md "Widget Release Flow" — when this PR merges, follow the standard widget release order:
1. Tag widget v3.3.160 → triggers npm publish
2. `cd app && npm install @marketrix.ai/widget@latest`
3. Use centralized deploy workflow in infra to deploy widget + app together

🤖 Generated with [Claude Code](https://claude.com/claude-code)