### PR TITLE
chore: remove dead code

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -287,10 +287,6 @@ export const initWidget = async (config: MarketrixConfig, container?: HTMLElemen
   if (initPromise) {
     return initPromise;
   }
-  if (isInitializing && initPromise) {
-    console.warn('Marketrix Widget: initialization already in progress');
-    return initPromise;
-  }
   if (isInitializing) {
     return Promise.resolve();
   }

--- a/src/utils/chat.ts
+++ b/src/utils/chat.ts
@@ -57,10 +57,6 @@ export function findTaskMessageIndex(messages: ChatMessage[]): number {
  * message finding code across stream handlers.
  */
 
-// import type { InstructionType } from '../types';
-// Remove self import
-// // import { findTaskMessageIndex } from './messageContentUtils';
-
 export interface FindMessageOptions {
   messages: ChatMessage[];
   isTaskRunning: boolean;


### PR DESCRIPTION
## Summary

- **Drop unreachable guard in `initWidget`** (`src/index.tsx`). `if (isInitializing && initPromise)` could never fire — the preceding `if (initPromise) return initPromise` already returned for any truthy `initPromise`, so the second condition was always false.
- **Remove commented-out imports in `src/utils/chat.ts`** left over from a refactor, including a `// // import` double-comment artifact.

Verified live (kept):
- `WidgetView = 'home' | 'chat' | 'help' | 'news'` — both `'help'` and `'news'` ARE rendered in `MessengerShell.tsx:242,270`. False positive in original audit.
- Schema items (`SimulationHistorySchema`, `TaskStatusSchema`) deferred to Tier 2 schema cleanup since they touch source-of-truth in `api/schema.ts`.

## Test plan

- [x] Pre-commit hooks pass (tsc + eslint)
- [ ] CI build green
- [ ] Verify widget initialization still gates on existing `initPromise` (manual)