### PR TITLE
chore: sync routes.ts from api source (insightResearchStatus POST→GET)

### DIFF
--- a/src/sdk/routes.ts
+++ b/src/sdk/routes.ts
@@ -17,7 +17,7 @@
  * - Widget: Widget configuration
  * - Connector: Automation triggers (user-facing: "Connectors")
  * - Chat: AI-powered chat and conversation management
- * - Tour: Guide system (user-facing: "Guides")
+ * - State Trigger: URL-pattern rules that swap widget chips per page (formerly UrlGuide)
  * - Activity Log: System activity tracking and auditing
  * - App Config: In-app configuration management
  * - Rule: Business rule management
@@ -2855,7 +2855,7 @@ const contract = {
 
   insightResearchStatus: oc
     .route({
-      method: 'POST',
+      method: 'GET',
       tags: ['Insight'],
       path: '/insights/{application_id}/research/status',
       summary: 'Check whether Background Research is currently running',


### PR DESCRIPTION
Mirror sync of api#401 — `insightResearchStatus` switches from POST to GET. SDK consumers will continue to compile because the input/output shape is unchanged.