### PR TITLE
chore(ci): bump GitHub Actions to versions used by ci-service.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: 'npm'
@@ -40,7 +40,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Resolve image tag
         id: tag
         run: |
@@ -52,9 +52,9 @@ jobs:
       - name: Log in to ACR
         run: az acr login --name marketrix
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Build and push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile
@@ -71,8 +71,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: 'npm'


### PR DESCRIPTION
## Summary
Widget runs its own CI (rather than the \`infra/ci-service.yml\` reusable) because it has unique steps — npm publish on tag, plus visual/a11y/bundle checks the other services don't run. But the action versions had drifted:

| Action | Before | After |
|---|---|---|
| actions/checkout | v4 | v6 |
| actions/setup-node | v4 | v6 |
| docker/setup-buildx | v3 | v4 |
| docker/build-push | v6 | v7 |

Aligning so the action surface matches the rest of the org. Behaviour unchanged.

## Test plan
- [ ] CI runs on PR (validate job)
- [ ] Next \`v*\` tag push triggers build + npm publish jobs and they succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)