### PR TITLE
chore(nginx): cache .webp alongside other static assets

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -21,7 +21,7 @@ server {
         add_header Access-Control-Allow-Origin *;
     }
 
-    location ~* \.(js|mjs|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+    location ~* \.(js|mjs|css|png|jpg|jpeg|gif|webp|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
         add_header Access-Control-Allow-Origin *;


### PR DESCRIPTION
Aligning the cached-asset pattern with website/nginx.conf which already covers .webp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)