### PR TITLE
chore(docker): align widget builder to node:25-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:25-slim AS builder
+FROM node:25-alpine AS builder
 
 WORKDIR /app
 COPY package*.json ./


### PR DESCRIPTION
Builder was on `node:25-slim` while this repo's own `Dockerfile.dev` uses `node:25-alpine`. Same node version, different libc — alpine matches the dev image and is consistent with how every other Node service in the org builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)