### PR TITLE
chore(widget): mirror api schema (drop legacy 'in_progress' from task union)

### DIFF
--- a/src/sdk/schema.ts
+++ b/src/sdk/schema.ts
@@ -51,8 +51,6 @@ export const LearningProgressSchema = z.object({
 export const KnowledgeTypeSchema = z.enum(['document', 'video']);
 export const KnowledgeSourceSchema = z.enum(['user', 'research']);
 export const QAFlowStatusSchema = z.enum(['pending', 'processing', 'waiting_review', 'completed', 'failed']);
-export const QATestStatusSchema = z.enum(['pending', 'in_progress', 'completed', 'failed']);
-export const QARunStatusSchema = z.enum(['pending', 'in_progress', 'completed', 'failed', 'stopped']);
 export const ChatRoleSchema = z.enum(['user', 'agent']);
 export const ChatSourceSchema = z.enum(['widget', 'app']);
 export const InstructionTypeSchema = z.enum(['tell', 'show', 'do']);
@@ -878,10 +876,7 @@ export const SimulationTaskEntrySchema = z.object({
   task_id: z.string(),
   title: z.string(),
   instructions: z.string(),
-  // Writers use 'running'; the legacy 'in_progress' string is kept on the
-  // union for backward read compat with old JSONB rows. New writes always
-  // emit 'running'.
-  status: z.enum(['pending', 'running', 'in_progress', 'has_question', 'passed', 'failed', 'skipped', 'stopped']),
+  status: z.enum(['pending', 'running', 'has_question', 'passed', 'failed', 'skipped', 'stopped']),
   error_message: z.string().nullish(),
   started_at: z.string().nullish(),
   completed_at: z.string().nullish(),


### PR DESCRIPTION
## Summary
Mirror `api/schema.ts`. `SimulationTaskEntry.status` no longer accepts `'in_progress'` (canonical is `'running'`); `QATestStatusSchema` and `QARunStatusSchema` are removed as dead code. No widget runtime code referenced these — widget only consumes them through the SDK type.

Net diff: **-6 / +1** in `src/sdk/schema.ts`.

## Cross-repo coordination
Pairs with Marketrix-ai/api#TBD (db migration + schema source) and Marketrix-ai/app#TBD. All three must deploy together.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 200/200 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)