### PR TITLE
chore(ci): migrate widget ci.yml to the shared reusable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,4 @@ jobs:
     uses: Marketrix-ai/infra/.github/workflows/ci-service.yml@dev
     with:
       service: widget
-      npm-publish: true
-      extra-validate-scripts: 'format:check,test:run,visual:check,a11y:check,bundle:check'
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,77 +9,10 @@ concurrency:
   group: ci-${{ startsWith(github.ref, 'refs/tags/') && github.sha || github.ref }}
   cancel-in-progress: true
 jobs:
-  validate:
-    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: 'npm'
-      - run: npm ci
-      - name: Type check
-        run: npm run type-check
-      - name: Lint
-        run: npm run lint 2>/dev/null || echo "No lint script"
-      - name: Build
-        run: npm run build
-      - name: Format check
-        run: npm run format:check
-      - name: Tests
-        run: npm run test:run
-      - name: Visual check
-        run: npm run visual:check
-      - name: Accessibility check
-        run: npm run a11y:check
-      - name: Bundle check
-        run: npm run bundle:check
-
-  build:
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Resolve image tag
-        id: tag
-        run: |
-          RAW="${GITHUB_REF#refs/tags/}"
-          echo "image_tag=${RAW#v}" >> $GITHUB_OUTPUT
-      - uses: azure/login@v3
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-      - name: Log in to ACR
-        run: az acr login --name marketrix
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-      - name: Build and push image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: Dockerfile
-          push: true
-          tags: marketrix.azurecr.io/widget:${{ steps.tag.outputs.image_tag }}
-          build-args: BUILD_COMMIT=${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          labels: |
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-
-  publish:
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
-      - run: npm run build
-      - name: Publish to npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  ci:
+    uses: Marketrix-ai/infra/.github/workflows/ci-service.yml@dev
+    with:
+      service: widget
+      npm-publish: true
+      extra-validate-scripts: 'format:check,test:run,visual:check,a11y:check,bundle:check'
+    secrets: inherit


### PR DESCRIPTION
## Summary

Drops 74 LOC by replacing widget's inlined validate/build/publish jobs with a single \`uses:\` of \`infra/.github/workflows/ci-service.yml@dev\`, matching every other service repo. Widget-only checks (\`format:check\`, \`test:run\`, \`visual:check\`, \`a11y:check\`, \`bundle:check\`) thread through the new \`extra-validate-scripts\` input added in [infra#45](https://github.com/Marketrix-ai/infra/pull/45).

## Side benefits picked up from the migration
- **Trivy image scan now runs on every widget tag** — the inlined build was missing it (every other service had it).
- **npm publish is now gated by the reusable's \`npm-publish\` input**, consistent with the rest of the org. Previous behavior published unconditionally on any \`v*\` tag.

## Test plan
- [x] Lefthook pre-commit (type-check + lint) passes locally
- [ ] Validate job runs all 5 widget-only checks under the "Extra validate scripts" step.
- [ ] Confirm next \`v*\` tag still triggers Docker build + npm publish (builds depend on tag, not on this PR).