### PR TITLE
fix(ci): inline project-sync (widget is public, infra reusable is private)

### DIFF
--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -1,14 +1,15 @@
 name: Project Sync
+# Inlined version — widget is public and GitHub Actions blocks public-repo
+# workflows from calling private-repo reusable workflows. The seven other
+# service repos (private) consume `project-sync-service.yml` from infra;
+# widget keeps its own copy here. Logic and option-name vocabulary mirror
+# the reusable so behavior stays consistent.
 on:
   issues:
     types: [opened, assigned, closed]
   pull_request:
     types: [opened, closed]
 
-# Reusable workflow needs write access to update issue/PR status on the project
-# board. Without an explicit block here the caller defaults to read-only and
-# the cross-repo call fails at startup because permissions cannot be elevated
-# by a callee.
 permissions:
   contents: read
   issues: write
@@ -16,5 +17,127 @@ permissions:
 
 jobs:
   sync:
-    uses: Marketrix-ai/infra/.github/workflows/project-sync-service.yml@dev
-    secrets: inherit
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.INFRA_PAT }}
+    steps:
+      - name: Resolve project IDs
+        id: ids
+        run: |
+          set -euo pipefail
+          data=$(gh api graphql -f query='
+            query {
+              organization(login: "Marketrix-ai") {
+                projectV2(number: 1) {
+                  id
+                  field(name: "Status") {
+                    ... on ProjectV2SingleSelectField {
+                      id
+                      options { id name }
+                    }
+                  }
+                }
+              }
+            }')
+          opt() { jq -r --arg n "$1" '.data.organization.projectV2.field.options[] | select(.name==$n) | .id' <<<"$data"; }
+          {
+            echo "project_id=$(jq -r '.data.organization.projectV2.id' <<<"$data")"
+            echo "field_id=$(jq -r '.data.organization.projectV2.field.id' <<<"$data")"
+            echo "backlog=$(opt Backlog)"
+            echo "ready=$(opt Ready)"
+            echo "in_review=$(opt 'In review')"
+            echo "done=$(opt Done)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Sync
+        env:
+          PROJECT_ID: ${{ steps.ids.outputs.project_id }}
+          STATUS_FIELD_ID: ${{ steps.ids.outputs.field_id }}
+          STATUS_BACKLOG: ${{ steps.ids.outputs.backlog }}
+          STATUS_READY: ${{ steps.ids.outputs.ready }}
+          STATUS_IN_REVIEW: ${{ steps.ids.outputs.in_review }}
+          STATUS_DONE: ${{ steps.ids.outputs.done }}
+          EVENT: ${{ github.event_name }}
+          ACTION: ${{ github.event.action }}
+          MERGED: ${{ github.event.pull_request.merged }}
+          ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -uo pipefail
+
+          add_item() {
+            gh api graphql -f query='
+              mutation($p: ID!, $c: ID!) {
+                addProjectV2ItemById(input: {projectId: $p, contentId: $c}) { item { id } }
+              }' -f p="$PROJECT_ID" -f c="$1" \
+              --jq '.data.addProjectV2ItemById.item.id' 2>/dev/null || true
+          }
+
+          set_status() {
+            [ -z "${1:-}" ] && return 0
+            gh api graphql -f query='
+              mutation($p: ID!, $i: ID!, $f: ID!, $v: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $p, itemId: $i, fieldId: $f, value: {singleSelectOptionId: $v}
+                }) { projectV2Item { id } }
+              }' -f p="$PROJECT_ID" -f i="$1" -f f="$STATUS_FIELD_ID" -f v="$2" >/dev/null
+          }
+
+          move_issue_node() { set_status "$(add_item "$1")" "$2"; }
+
+          extract_closes() {
+            { echo "$1" | grep -ioP '(?:closes|fixes|resolves)\s+#\K\d+' || true; } | head -1
+          }
+
+          issue_node_for_num() {
+            gh api "/repos/$REPO/issues/$1" --jq '.node_id' 2>/dev/null || true
+          }
+
+          case "$EVENT:$ACTION" in
+            issues:opened)
+              move_issue_node "$ISSUE_NODE_ID" "$STATUS_BACKLOG"
+              ;;
+            issues:assigned)
+              move_issue_node "$ISSUE_NODE_ID" "$STATUS_READY"
+              ;;
+            issues:closed)
+              move_issue_node "$ISSUE_NODE_ID" "$STATUS_DONE"
+              ;;
+            pull_request:opened)
+              gh pr edit "$PR_NUMBER" -R "$REPO" --add-reviewer Marketrix-ai/dev 2>/dev/null || true
+
+              num=$(extract_closes "$PR_BODY")
+              if [ -z "$num" ]; then
+                if url=$(gh issue create -R "$REPO" --title "$PR_TITLE" \
+                          --body "Auto-created from $PR_URL" --assignee "$PR_AUTHOR" 2>&1); then
+                  num=$(echo "$url" | grep -oP '\d+$')
+                  body="Closes #${num}"
+                  [ -n "$PR_BODY" ] && body="${body}"$'\n\n'"${PR_BODY}"
+                  gh pr edit "$PR_NUMBER" -R "$REPO" --body "$body"
+                  echo "Created issue #$num and linked to PR #$PR_NUMBER"
+                else
+                  echo "::warning::tracking-issue auto-create skipped: $url"
+                  exit 0
+                fi
+              fi
+
+              node=$(issue_node_for_num "$num")
+              [ -n "$node" ] && move_issue_node "$node" "$STATUS_IN_REVIEW"
+              ;;
+            pull_request:closed)
+              num=$(extract_closes "$PR_BODY")
+              [ -z "$num" ] && exit 0
+              node=$(issue_node_for_num "$num")
+              [ -z "$node" ] && exit 0
+              if [ "$MERGED" = "true" ]; then
+                move_issue_node "$node" "$STATUS_DONE"
+              else
+                move_issue_node "$node" "$STATUS_READY"
+              fi
+              ;;
+          esac


### PR DESCRIPTION
Closes #154

## The bug

[#151](https://github.com/Marketrix-ai/widget/pull/151) migrated widget's \`project-sync.yml\` to call the shared reusable in \`Marketrix-ai/infra\`. **Every Project Sync run since has died at startup with no jobs scheduled** — widget is the only public repo in the org, and GitHub Actions blocks public-repo workflows from calling reusable workflows in private repos.

(Confirmed by closing [#152](https://github.com/Marketrix-ai/widget/pull/152) — even the absolute minimal \`uses: ...ci-service.yml\` call from widget produces \`startup_failure, referenced_workflows: []\`, identical symptom.)

## The fix

Inline the project-sync logic again, but in the same cleaned-up shape as the reusable so the two stay in lockstep:

- **Dynamic resolution** of project + Status field + option IDs by name (no hardcoded GraphQL node IDs).
- **One dispatch step** with shared bash helpers instead of one step per event branch — single \`case\` on \`\$EVENT:\$ACTION\`.
- **Closed-unmerged PRs move the linked issue back to "Ready"** instead of \`deleteProjectV2Item\` — fixes the silent-board-history-loss bug that motivated #151 in the first place.
- **Auto-create a tracking issue** when a PR opens without a \`Closes #N\` reference.
- Drops the unused \`STATUS_IN_PROGRESS\` env var.

## Long-term

If widget moves to private (or infra goes public), this file can be replaced with the same 18-line caller every other repo uses. Until then the inline copy is the only thing that actually runs.