### PR TITLE
fix(ci): make npm publish idempotent in inlined widget workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,18 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run build
+      # Sync-tagging an unchanged widget doesn't bump package.json, so the
+      # version we'd publish is already on the registry. Skip in that case
+      # rather than fail the run with "cannot publish over previously
+      # published versions". Mirrors infra/.github/workflows/ci-service.yml.
       - name: Publish to npm
-        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          NAME=$(node -p "require('./package.json').name")
+          VER=$(node -p "require('./package.json').version")
+          if npm view "$NAME@$VER" version >/dev/null 2>&1; then
+            echo "Already on registry: $NAME@$VER — skipping publish"
+            exit 0
+          fi
+          npm publish --access public


### PR DESCRIPTION
Closes #156

Mirror of [infra#47](https://github.com/Marketrix-ai/infra/pull/47) for widget's inlined `ci.yml` (widget can't use the reusable due to the public→private cross-repo restriction).

## The bug

Sync-tagging an unchanged widget doesn't bump `package.json`, so the version on disk equals the version already published on npm. The publish step previously failed with `cannot publish over previously published versions`, turning the whole CI run red — exactly what happened on the v3.3.179 release.

## Fix

One `npm view` lookup before `npm publish`; skip with `exit 0` if the (name, version) is already on the registry. Idempotent for sync-tags; unchanged for genuine widget releases.

## Test plan
- [ ] Sync-tagging widget at the same package.json version produces a green run with "Already on registry — skipping".
- [ ] Genuine release with version bump still publishes.