### PR TITLE
chore: sync Application.slug into SDK schema mirror (cross-cutting)

### DIFF
--- a/src/sdk/schema.ts
+++ b/src/sdk/schema.ts
@@ -1303,6 +1303,7 @@ export const AgentSimulationIndexResponseSchema = z.object({
 export const ApplicationEntitySchema = BaseEntitySchema.extend({
   workspace_id: z.number(),
   name: z.string(),
+  slug: z.string(),
   type: ApplicationTypeSchema,
   url: z.string().nullish(),
   username: z.string().nullish(),
@@ -1329,7 +1330,7 @@ export const ApplicationCreateSchema = ApplicationEntitySchema.partial().extend(
 /**
  * Application update schema
  */
-export const ApplicationUpdateSchema = ApplicationEntitySchema.partial().omit({ workspace_id: true });
+export const ApplicationUpdateSchema = ApplicationEntitySchema.partial().omit({ workspace_id: true, slug: true });
 
 // ============================================================================
 // WIDGET SCHEMAS - Widget management (widget, slack, etc.)


### PR DESCRIPTION
Closes #167

## Summary
Part of a **cross-cutting** change (api + app + widget): the URL-based application scoping work adds an immutable `Application.slug` to the API contract.

**This repo (widget):** mirror-only — `src/sdk/schema.ts` `ApplicationEntitySchema` gains `slug: z.string()` and `ApplicationUpdateSchema` omits `slug`, keeping the shared contract in exact sync with `api/schema.ts` (source of truth). No widget runtime/behavior change; widget is not workspace-routed. Type-parity only.

## ⚠️ Deploy ordering
Widget is **decoupled** — can deploy any time independent of api/app. Companion PRs: `Marketrix-ai/api#482`, `Marketrix-ai/app#555`.

## Test plan
- [x] `npm run type-check` clean.
- No runtime change; nothing else to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)