### PR TITLE
chore(widget): sync schema (drop vector_index_created) — item 15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@marketrix.ai/widget",
-  "version": "3.3.236",
+  "version": "3.3.237",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@marketrix.ai/widget",
-      "version": "3.3.236",
+      "version": "3.3.237",
       "dependencies": {
         "@base-ui/react": "^1.5.0",
         "@orpc/client": "^1.14.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marketrix.ai/widget",
-  "version": "3.3.236",
+  "version": "3.3.237",
   "type": "module",
   "main": "./dist/widget.mjs",
   "module": "./dist/widget.mjs",

--- a/src/sdk/schema.ts
+++ b/src/sdk/schema.ts
@@ -11,7 +11,6 @@ export const AgentStatusSchema = z.enum(['active', 'learning', 'error']);
 // - true: callback received with success
 // - false: callback received with failure
 export const LearningProgressSchema = z.object({
-  vector_index_created: z.boolean().nullable(),
   graph_index_created: z.boolean().nullable(),
 });
 export const KnowledgeTypeSchema = z.enum(['document', 'video']);


### PR DESCRIPTION
Closes #177

## Summary

Widget-side companion to api PR #537, agent PR #315, and app PR #591 for item 15. Syncs the `LearningProgressSchema` field drop from `api/schema.ts`.

The widget doesn't render learning progress UI; this is a contract-mirror hygiene change to keep the SDK schema aligned with the api source of truth per the "Shared Contracts" rule in CLAUDE.md.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] Schema mirror matches `api/schema.ts` (zero diff)

## Coordination

Deploy after api #537 lands. Field drop is wire-tolerant per `project_orpc_no_runtime_validation` memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)