### PR TITLE
chore(widget): sync sdk mirrors with api 3.3.252 + version 3.3.241

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@marketrix.ai/widget",
-  "version": "3.3.240",
+  "version": "3.3.241",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@marketrix.ai/widget",
-      "version": "3.3.240",
+      "version": "3.3.241",
       "dependencies": {
         "@base-ui/react": "^1.5.0",
         "@orpc/client": "^1.14.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marketrix.ai/widget",
-  "version": "3.3.240",
+  "version": "3.3.241",
   "type": "module",
   "main": "./dist/widget.mjs",
   "module": "./dist/widget.mjs",

--- a/src/sdk/routes.ts
+++ b/src/sdk/routes.ts
@@ -94,9 +94,6 @@ import {
   PlanCatalogSchema,
   PlanInfoSchema,
   PortalSessionSchema,
-  PreviewVideoChatEntitySchema,
-  PreviewVideoChatSearchSchema,
-  PreviewVideoChatUpsertSchema,
   ProviderEntitySchema,
   ProviderNameSchema,
   PublicConfigSchema,
@@ -681,39 +678,6 @@ const contract = {
       }),
     )
     .output(UserQuotaSchema),
-
-  previewVideoChatUpsert: oc
-    .route({
-      method: 'POST',
-      tags: ['Chat'],
-      path: '/preview-video-chat',
-      summary: 'Create or update preview video chat record',
-      description: 'Persists guide preview chat content, history, output, and related simulation metadata',
-    })
-    .input(PreviewVideoChatUpsertSchema)
-    .output(PreviewVideoChatEntitySchema),
-
-  previewVideoChatSearch: oc
-    .route({
-      method: 'GET',
-      tags: ['Chat'],
-      path: '/preview-video-chat',
-      summary: 'Search preview video chat records',
-      description: 'Returns preview chat records filtered by chat_id, agent_id, or simulation_id for current workspace',
-    })
-    .input(PreviewVideoChatSearchSchema)
-    .output(listOf(PreviewVideoChatEntitySchema)),
-
-  previewVideoChatGet: oc
-    .route({
-      method: 'GET',
-      tags: ['Chat'],
-      path: '/preview-video-chat/{id}',
-      summary: 'Get preview video chat record by ID',
-      description: 'Returns a single preview chat record for current workspace',
-    })
-    .input(ByIdSchema)
-    .output(PreviewVideoChatEntitySchema.nullable()),
 
   connectorUpsert: oc
     .route({
@@ -2520,38 +2484,6 @@ const contract = {
           overallPassed: z.number(),
           overallFailed: z.number(),
         }),
-      }),
-    ),
-
-  qaCrossBrowserComparison: oc
-    .route({
-      method: 'GET',
-      tags: ['QA'],
-      path: '/qa/document/{id}/cross-browser-comparison',
-      summary: 'Get cross-browser comparison',
-      description: 'Returns test cases comparison across different browsers',
-    })
-    .input(ByIdSchema)
-    .output(
-      z.object({
-        byTest: z.record(
-          z.string(),
-          z.record(
-            z.string(),
-            z.object({
-              status: z.string(),
-              runId: z.number(),
-            }),
-          ),
-        ),
-        byBrowser: z.record(
-          z.string(),
-          z.object({
-            passed: z.number(),
-            failed: z.number(),
-            total: z.number(),
-          }),
-        ),
       }),
     ),
 

--- a/src/sdk/schema.ts
+++ b/src/sdk/schema.ts
@@ -18,13 +18,15 @@ export const KnowledgeSourceSchema = z.enum(['user', 'research']);
 export const QAFlowStatusSchema = z.enum(['pending', 'processing', 'waiting_review', 'completed', 'failed']);
 /**
  * Simulation parent status — canonical wire vocabulary matching the
- * `simulation_status` Postgres ENUM. `has_question` is intentionally absent;
- * it's a per-task state surfaced as a derived `has_question` boolean.
+ * `simulation_status` Postgres ENUM and the `SimulationStatus` proto enum.
+ * Wave-14 added `has_question` (parent reflects a task awaiting answer);
+ * V56 migration adds the corresponding PG enum value.
  */
 export const SimulationStatusSchema = z.enum([
   'queued',
   'running',
   'creating_knowledge',
+  'has_question',
   'completed',
   'failed',
   'stopped',
@@ -1007,7 +1009,6 @@ export const AgentEntitySchema = BaseEntitySchema.extend({
   instructions: z.string().nullish(),
   image_url: z.string().nullish(),
   graph_index_id: z.string().nullish(),
-  vector_store_id: z.string().nullish(),
   status: AgentStatusSchema,
   status_message: z.string().nullish(),
   learning_progress: LearningProgressSchema.nullish(),


### PR DESCRIPTION
Closes #185

## Summary

SDK mirror sync after api#565 (3.3.251 -> 3.3.252) shipped. Removes:
- agent.vector_store_id field from AgentEntitySchema
- previewVideoChat{Get,Search,Upsert} oRPC routes
- qaCrossBrowserComparison oRPC route

src/sdk/{routes,schema}.ts now byte-identical with api/{routes,schema}.ts at origin/dev (commit fce8128b).

Zero widget-side callers of the dropped surfaces (verified via grep against /src outside /src/sdk).

## Version
3.3.240 -> 3.3.241

## Test plan

- [x] diff -q against api source: no diff for both files
- [x] npm run check (tsc --noEmit) clean
- [x] npm run build clean
- [x] npm test -- --run: 200/200 pass
- [ ] CI passes