### PR TITLE
chore(widget): sync sdk routes mirror with api 3.3.254

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@marketrix.ai/widget",
-  "version": "3.3.241",
+  "version": "3.3.242",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@marketrix.ai/widget",
-      "version": "3.3.241",
+      "version": "3.3.242",
       "dependencies": {
         "@base-ui/react": "^1.5.0",
         "@orpc/client": "^1.14.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marketrix.ai/widget",
-  "version": "3.3.241",
+  "version": "3.3.242",
   "type": "module",
   "main": "./dist/widget.mjs",
   "module": "./dist/widget.mjs",

--- a/src/sdk/routes.ts
+++ b/src/sdk/routes.ts
@@ -1329,18 +1329,6 @@ const contract = {
     .input(AgentSimulationIndexRequestSchema.extend({ agent_id: z.coerce.number() }))
     .output(AgentSimulationIndexResponseSchema),
 
-  agentResetLearning: oc
-    .route({
-      method: 'POST',
-      tags: ['Agent'],
-      path: '/agent/{agent_id}/reset-learning',
-      summary: 'Force reset agent from stuck learning state',
-      description:
-        'Resets an agent that is stuck in learning state, setting it to error status with a message explaining the reset',
-    })
-    .input(ByAgentIdSchema)
-    .output(AgentEntitySchema),
-
   activityLogCreate: oc
     .route({
       method: 'POST',


### PR DESCRIPTION
Closes #187

## Summary

- Drop `agentResetLearning` from `src/sdk/routes.ts` to match api 3.3.254.

Bumps widget 3.3.241 → 3.3.242.

## Companion

- API PR: https://github.com/Marketrix-ai/api/pull/569
- App PR: https://github.com/Marketrix-ai/app/pull/605

## Test plan

- [x] `tsc --noEmit` clean.
- [x] No widget source references `agentResetLearning`.
- [ ] CI green.