### PR TITLE
chore(widget): drop dead zero-caller routes (user-mgmt + admin)

### DIFF
--- a/src/sdk/routes.ts
+++ b/src/sdk/routes.ts
@@ -26,8 +26,6 @@ import {
   AutomationRunSearchSchema,
   AutomationSearchSchema,
   AutomationUpdateSchema,
-  BatchUserCreateResultSchema,
-  BatchUserCreateSchema,
   BrowserConfigSchema,
   BrowserTypeSchema,
   ByAgentIdSchema,
@@ -48,8 +46,6 @@ import {
   DomainPersonaSuggestResponseSchema,
   EntityStatusSchema,
   FailureAnalysisSchema,
-  FileSchema,
-  FileUploadResponseSchema,
   GithubRepoSchema,
   GithubWorkflowRunSchema,
   HealthResponseSchema,
@@ -429,79 +425,6 @@ const contract = {
       description: 'Returns all workspaces the authenticated user belongs to, including their role in each.',
     })
     .output(listOf(WorkspaceEntitySchema.extend({ role: WorkspaceMemberRoleSchema }))),
-
-  // Admin
-  adminReconcile: oc
-    .route({
-      method: 'POST',
-      path: '/admin/reconcile',
-      tags: ['Internal'],
-      summary: 'Reconcile Stripe customers and WorkOS users',
-      description:
-        'Backfills missing Stripe customer IDs for workspaces and real WorkOS user IDs for users. Idempotent and safe to run repeatedly. Requires super user role.',
-    })
-    .output(
-      z.object({
-        workspaces_stripe_created: z.number(),
-        users_workos_created: z.number(),
-        workspace_plans_synced: z.number(),
-        trials_provisioned: z.number(),
-        stripe_plans_refreshed: z.number(),
-        workos_profiles_synced: z.number(),
-        errors: z.array(
-          z.object({
-            type: z.string(),
-            id: z.number(),
-            error: z.string(),
-          }),
-        ),
-      }),
-    ),
-
-  adminMaintenance: oc
-    .route({
-      method: 'POST',
-      path: '/admin/maintenance',
-      tags: ['Internal'],
-      summary: 'Run periodic maintenance cleanup tasks',
-      description:
-        'Cleans up QA simulations not linked to existing runs and orphaned blob storage files. Idempotent and safe to run repeatedly. Requires super user role.',
-    })
-    .output(
-      z.object({
-        orphaned_qa_simulations_deleted: z.number(),
-        orphaned_blob_dirs_deleted: z.number(),
-        errors: z.array(
-          z.object({
-            type: z.string(),
-            detail: z.string(),
-          }),
-        ),
-      }),
-    ),
-
-  adminRebuild: oc
-    .route({
-      method: 'POST',
-      path: '/admin/rebuild',
-      tags: ['Internal'],
-      summary: 'Rebuild all agent indexes after cleanup',
-      description:
-        'Removes stale knowledge (missing files), stale simulations (0 steps or missing blobs), then deletes and recreates vector stores and knowledge graphs for every agent. Index creation is async. Requires super user role.',
-    })
-    .output(
-      z.object({
-        knowledge_removed: z.number(),
-        simulations_removed: z.number(),
-        agents_rebuilt: z.number(),
-        errors: z.array(
-          z.object({
-            type: z.string(),
-            detail: z.string(),
-          }),
-        ),
-      }),
-    ),
 
   applicationCreate: oc
     .route({
@@ -1169,17 +1092,6 @@ const contract = {
     )
     .output(paginatedListOf(UserEntitySchema)),
 
-  userCreateBatch: oc
-    .route({
-      method: 'POST',
-      tags: ['User'],
-      path: '/user/batch',
-      summary: 'Create multiple users in batch operation',
-      description: 'Processes bulk user creation and returns results for each user',
-    })
-    .input(BatchUserCreateSchema)
-    .output(z.array(BatchUserCreateResultSchema)),
-
   userGet: oc
     .route({
       method: 'GET',
@@ -1201,40 +1113,6 @@ const contract = {
     })
     .input(UserUpdateSchema.extend({ user_id: z.coerce.number() }))
     .output(UserEntitySchema),
-
-  userUpdateImage: oc
-    .route({
-      method: 'PUT',
-      tags: ['User'],
-      path: '/user/{user_id}/image',
-      summary: 'Upload and update user profile image',
-      description: 'Handles file upload for user avatar and returns upload response',
-    })
-    .input(FileSchema.extend({ user_id: z.coerce.number() }))
-    .output(FileUploadResponseSchema),
-
-  userDelete: oc
-    .route({
-      method: 'DELETE',
-      tags: ['User'],
-      path: '/user/{user_id}',
-      summary: 'Delete user account and all associated data',
-      description:
-        'Permanently deletes a user account and cleans up all related resources. This action cannot be undone.',
-    })
-    .input(ByUserIdSchema)
-    .output(SuccessSchema),
-
-  userDeactivate: oc
-    .route({
-      method: 'POST',
-      tags: ['User'],
-      path: '/user/{user_id}/deactivate',
-      summary: 'Deactivate user account without deletion',
-      description: 'Deactivates user access while preserving data for potential reactivation',
-    })
-    .input(ByUserIdSchema.extend({ reason: z.string().optional() }))
-    .output(SuccessSchema),
 
   agentCreate: oc
     .route({


### PR DESCRIPTION
Closes #189

## Summary
Syncs the SDK routes mirror (`src/sdk/routes.ts`) with the API source of truth — drops 7 oRPC routes that have **zero callers** anywhere in the platform.

### Routes removed (mirror sync)
**user-management**: `userCreateBatch`, `userUpdateImage`, `userDelete`, `userDeactivate`
**admin**: `adminReconcile`, `adminMaintenance`, `adminRebuild`

All confirmed zero-caller across `app/src`, `widget/src`, `agent`, `docs` (excluding SDK mirrors) before removal.

### Files changed
- `src/sdk/routes.ts` — kept byte-identical to the edited `api/routes.ts`. Removed the 7 contract blocks plus the now-dead schema imports (`BatchUserCreate*`, `FileSchema`, `FileUploadResponseSchema`).

`src/sdk/schema.ts` is unchanged (the removed routes' schemas remain shared with surviving API code).

### Verification
- `npm run type-check` — passes, 0 errors (also ran via pre-commit hook).

Pairs with the API PR (source of truth) and the app mirror PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)