### PR TITLE
perf(widget): drop oRPC contract from the embeddable bundle (−54 kB / −12 kB gzip)

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/yasith/code/marketrix/widget/node_modules

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -70,5 +70,8 @@ export const sdk = new Proxy({} as ContractRouterClient<typeof contract> & SdkEx
 // Export all types from schema
 export * from './schema';
 
-// Export contract from routes
-export { contract } from './routes';
+// Type-only export: the oRPC client builds requests from the proxied path and
+// never needs the `contract` VALUE at runtime. Re-exporting the value pulled the
+// whole routes.ts contract (and the 291 zod schemas it references) into the
+// embeddable bundle. Keeping it type-only drops all of that from the shipped JS.
+export type { contract } from './routes';


### PR DESCRIPTION
Closes #198

## Summary
`src/sdk/index.ts` re-exported the `contract` **value** from `routes.ts`, dragging the entire 2,696-LOC oRPC contract + the 291 zod schemas it references into the shipped embeddable bundle. The oRPC client builds requests from the proxied path and never needs the contract value at runtime; nothing in the widget (or the package's public API) imports it as a value.

Changed it to `export type { contract }` — the **type** stays available (`ContractRouterClient<typeof contract>` + the package `.d.ts`), but the runtime value (and `routes.ts`) is tree-shaken out.

**Bundle:** `dist/widget.mjs` 615.71 → **561.69 kB** raw (−54 kB), gzip 171.75 → **159.49 kB** (−12 kB).

### Deferred (L2)
Lazy-loading `ToolService`/`DomService` (~1.6k LOC) needs code-splitting, which would break the single-file embed contract (third-party hosts load one `dist/widget.mjs`). Needs a serving-model decision — out of scope here.

## Verification
- `tsc` 0 errors · 204 tests pass · ESLint (`--max-warnings 0`) + Prettier clean · `.d.ts` still exports the contract type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)