### PR TITLE
refactor(widget): single-source state + pure SSE reducer

### DIFF
--- a/src/context/ChatContext.tsx
+++ b/src/context/ChatContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
 
 import { MarketrixApiService } from '../services/ApiService';
-import { chatService, createAgentMessage, createUserMessage } from '../services/ChatService';
+import { createAgentMessage, createUserMessage } from '../services/ChatService';
 import { configManager } from '../services/ConfigManager';
 import { StreamClient } from '../services/StreamClient';
 import type { ChatMessage, InstructionType } from '../types';
@@ -70,35 +70,24 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
   currentModeRef.current = currentMode;
 
   const addMessage = useCallback((message: ChatMessage) => {
-    setChatState(prev => {
-      chatService.addMessage(message);
-      return { messages: [...prev.messages, message] };
-    });
+    setChatState(prev => ({ messages: [...prev.messages, message] }));
   }, []);
 
   const updateMessage = useCallback((messageId: string, updates: Partial<ChatMessage>) => {
-    setChatState(prev => {
-      chatService.updateMessage(messageId, updates);
-      return { messages: prev.messages.map(msg => (msg.id === messageId ? { ...msg, ...updates } : msg)) };
-    });
+    setChatState(prev => ({
+      messages: prev.messages.map(msg => (msg.id === messageId ? { ...msg, ...updates } : msg)),
+    }));
   }, []);
 
   const removeMessage = useCallback((messageId: string) => {
-    setChatState(prev => {
-      chatService.removeMessage(messageId);
-      return { messages: prev.messages.filter(msg => msg.id !== messageId) };
-    });
+    setChatState(prev => ({ messages: prev.messages.filter(msg => msg.id !== messageId) }));
   }, []);
 
   const setMessages = useCallback((messages: ChatMessage[]) => {
-    setChatState(() => {
-      chatService.setMessages(messages);
-      return { messages };
-    });
+    setChatState({ messages });
   }, []);
 
   const clearMessages = useCallback(() => {
-    chatService.clearMessages();
     setChatState({ messages: [] });
   }, []);
 
@@ -196,7 +185,6 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
             const newParts = [...(msg.parts ?? []), { type: 'text' as const, content: errorMessage }];
             return { ...msg, isPlaceholder: false, parts: newParts, content: errorMessage };
           });
-          chatService.setMessages(newMessages);
           return { messages: newMessages };
         });
       } finally {

--- a/src/context/TaskContext.tsx
+++ b/src/context/TaskContext.tsx
@@ -1,20 +1,12 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 
 import type { WidgetEvent } from '../sdk/schema';
-import { chatService } from '../services/ChatService';
 import { StreamClient, type StreamStatus } from '../services/StreamClient';
 import { toolExecutionService } from '../services/ToolService';
-import type { InstructionType, TaskProgress } from '../types';
+import type { ChatMessage, InstructionType, TaskProgress } from '../types';
 import { BROWSER_TOOLS } from '../types/browserTools';
-import {
-  addProgressLine,
-  findMessageForProgress,
-  getFriendlyToolName,
-  markProgressLineComplete,
-  markProgressLineFailed,
-  updateThinkingMarker,
-} from '../utils/chat';
 import type { ChatState } from './ChatContext';
+import { reduceSse, reduceStop, reduceToolDone, reduceToolProgress, type SseEffect, type SseState } from './sseReducer';
 import type { UIStateActions } from './UIStateContext';
 
 // ---------------------------------------------------------------------------
@@ -58,6 +50,8 @@ interface TaskProviderProps {
   currentMode: InstructionType;
   /** Injected from WidgetProviders to let SSE mutate messages. */
   setMessages: React.Dispatch<React.SetStateAction<ChatState>>;
+  /** Live snapshot of the current messages, so SSE wiring reads without stale closures. */
+  messagesRef: React.MutableRefObject<ChatMessage[]>;
   /** Injected UI actions needed for agentAvailable, setLoading. */
   uiActions: Pick<UIStateActions, 'setAgentAvailable' | 'setError' | 'setLoading'>;
   /** Injected so stopTask can read the current activeTaskId without a stale closure. */
@@ -69,6 +63,7 @@ export const TaskProvider: React.FC<TaskProviderProps> = ({
   previewMode = false,
   currentMode,
   setMessages,
+  messagesRef,
   uiActions,
   activeTaskIdRef,
 }) => {
@@ -78,8 +73,9 @@ export const TaskProvider: React.FC<TaskProviderProps> = ({
     taskProgress: [],
   });
 
-  // Stable refs for use inside SSE callbacks that must not stale-close over state
-  const isTaskRunningRef = useRef(false);
+  // Live task snapshot for SSE wiring that must not stale-close over state.
+  const taskRef = useRef<TaskState>(taskState);
+  taskRef.current = taskState;
   const stateVersion = useRef(0);
   const processedRequestIds = useRef(new Set<string>());
   const pendingTaskRef = useRef<{ apiTaskId?: string; agentRunning?: boolean }>({});
@@ -102,59 +98,28 @@ export const TaskProvider: React.FC<TaskProviderProps> = ({
   }, []);
 
   // -------------------------------------------------------------------------
-  // Internal helper — update progress lines inside a message
+  // Run a pure transition against the live state and commit the result into the
+  // two React stores. The reducer owns every message/task transition; reading
+  // messages through the functional `setMessages` updater keeps the snapshot
+  // current even mid-burst (no stale ref). Task is read from `taskRef` — it only
+  // ever changes through this same path.
   // -------------------------------------------------------------------------
-  const updateProgressForTool = useCallback(
-    (toolName: string, explanation: string, status: 'in_progress' | 'completed' | 'failed', error?: string) => {
+  const commit = useCallback(
+    (transition: (state: SseState) => SseState) => {
+      const taskBefore = { activeTaskId: taskRef.current.activeTaskId, isTaskRunning: taskRef.current.isTaskRunning };
+      let nextTask = taskBefore;
       setMessages(prev => {
-        const friendlyName = getFriendlyToolName(toolName);
-        const found = findMessageForProgress({
-          messages: prev.messages,
-          isTaskRunning: isTaskRunningRef.current,
-          currentMode: currentModeRef.current,
-          requireContent: status === 'failed',
-        });
-        if (!found) return prev;
-
-        let updatedMsg = found.message;
-        const isInteractiveTool = [
-          'click_element',
-          'type_text',
-          'select_dropdown_option',
-          'send_keys',
-          'upload_file',
-        ].includes(toolName);
-        const shouldWait = isTaskRunningRef.current && currentModeRef.current === 'show' && isInteractiveTool;
-        const isDoneTool = toolName === 'done';
-
-        if (status === 'in_progress') {
-          if (!isDoneTool) {
-            updatedMsg = addProgressLine(updatedMsg, friendlyName, explanation || friendlyName);
-          }
-          if (isTaskRunningRef.current && (currentModeRef.current === 'show' || currentModeRef.current === 'do')) {
-            updatedMsg = updateThinkingMarker(updatedMsg, isTaskRunningRef.current, currentModeRef.current, shouldWait);
-          }
-        } else if (status === 'completed') {
-          if (!isDoneTool) {
-            updatedMsg = markProgressLineComplete(updatedMsg);
-          }
-          if (isTaskRunningRef.current && (currentModeRef.current === 'show' || currentModeRef.current === 'do')) {
-            updatedMsg = updateThinkingMarker(updatedMsg, isTaskRunningRef.current, currentModeRef.current, false);
-          }
-        } else {
-          updatedMsg = markProgressLineFailed(updatedMsg, friendlyName, error || '');
-          if (isTaskRunningRef.current && (currentModeRef.current === 'show' || currentModeRef.current === 'do')) {
-            updatedMsg = updateThinkingMarker(updatedMsg, isTaskRunningRef.current, currentModeRef.current, false);
-          }
-        }
-
-        const newMessages = [...prev.messages];
-        newMessages[found.index] = updatedMsg;
-        chatService.setMessages(newMessages);
-        return { messages: newMessages };
+        const next = transition({ messages: prev.messages, task: taskBefore });
+        nextTask = next.task;
+        messagesRef.current = next.messages;
+        return next.messages === prev.messages ? prev : { messages: next.messages };
       });
+      if (nextTask.isTaskRunning !== taskBefore.isTaskRunning || nextTask.activeTaskId !== taskBefore.activeTaskId) {
+        taskRef.current = { ...taskRef.current, ...nextTask, taskProgress: [] };
+        setTaskState_(taskRef.current);
+      }
     },
-    [],
+    [setMessages, messagesRef],
   );
 
   // -------------------------------------------------------------------------
@@ -165,16 +130,12 @@ export const TaskProvider: React.FC<TaskProviderProps> = ({
     if (p.apiTaskId && p.agentRunning) {
       const taskId = p.apiTaskId;
       pendingTaskRef.current = {};
-      setTaskState_(prev => {
-        chatService.setTaskState(true, taskId, []);
-        isTaskRunningRef.current = true;
-        return { ...prev, isTaskRunning: true, activeTaskId: taskId, taskProgress: [] };
-      });
+      commit(state => ({ ...state, task: { isTaskRunning: true, activeTaskId: taskId } }));
     }
-  }, []);
+  }, [commit]);
 
   // -------------------------------------------------------------------------
-  // SSE Event Handler
+  // SSE Event Handler — thin wiring over the pure reducer.
   // -------------------------------------------------------------------------
   useEffect(() => {
     if (previewMode) return;
@@ -185,10 +146,72 @@ export const TaskProvider: React.FC<TaskProviderProps> = ({
       uiActions.setAgentAvailable(status === 'registered');
     };
 
+    const runEffects = (effects: SseEffect[]) => {
+      for (const effect of effects) {
+        if (effect.type === 'setLoading') {
+          uiActions.setLoading(effect.value);
+        } else if (effect.type === 'activateApiTask') {
+          pendingTaskRef.current = { ...pendingTaskRef.current, apiTaskId: effect.taskId };
+          maybeActivateTask();
+        }
+      }
+    };
+
+    const executeToolCall = async (effect: Extract<SseEffect, { type: 'executeTool' }>) => {
+      const { callId, tool, args, mode, explanation } = effect;
+      const result = await toolExecutionService.executeTool(tool, args, mode, explanation);
+
+      if (result.success) {
+        try {
+          stateVersion.current++;
+          wsClient
+            .send({
+              type: 'tool/response',
+              call_id: callId,
+              success: true,
+              data: typeof result.data === 'string' ? result.data : JSON.stringify(result.data),
+              state_version: stateVersion.current,
+            })
+            .catch(err => console.error('Failed to send tool success response:', err));
+          commit(s => reduceToolProgress(s, tool, explanation, 'completed', currentModeRef.current));
+
+          if (tool === 'done') {
+            pendingTaskRef.current = {};
+            commit(s => reduceToolDone(s, currentModeRef.current));
+          }
+        } catch (error) {
+          console.error('Failed to send tool result:', error);
+          commit(s => reduceToolProgress(s, tool, explanation, 'failed', currentModeRef.current, 'Connection error'));
+        }
+      } else {
+        commit(s =>
+          reduceToolProgress(
+            s,
+            tool,
+            explanation,
+            'failed',
+            currentModeRef.current,
+            result.error || 'Tool execution failed',
+          ),
+        );
+        stateVersion.current++;
+        wsClient
+          .send({
+            type: 'tool/response',
+            call_id: callId,
+            success: false,
+            data: typeof result.data === 'string' ? result.data : JSON.stringify(result.data),
+            error: result.error ?? undefined,
+            state_version: stateVersion.current,
+          })
+          .catch(err => console.error('Failed to send tool error response:', err));
+      }
+    };
+
     const handleMessage = async (event: WidgetEvent) => {
+      // Transport bookkeeping that must run before the pure reducer.
       if (event.type === 'tool/call') {
         const requestId = event.call_id;
-
         if (processedRequestIds.current.has(requestId)) return;
         addProcessedRequestId(requestId);
 
@@ -207,196 +230,41 @@ export const TaskProvider: React.FC<TaskProviderProps> = ({
           return;
         }
 
-        if (!isTaskRunningRef.current) {
+        if (!taskRef.current.isTaskRunning) {
           console.log('[Widget] Tool call received before task/status running — auto-activating task');
-          isTaskRunningRef.current = true;
-          setTaskState_(prev => ({ ...prev, isTaskRunning: true }));
         }
-
-        const toolName = event.tool;
-        const args = event.args;
-        const mode = event.mode || currentModeRef.current || 'do';
-        const explanation = event.explanation || '';
-        const requestStateVersion = event.state_version;
-
-        if (requestStateVersion !== undefined && requestStateVersion > stateVersion.current) {
-          stateVersion.current = requestStateVersion;
+        if (event.state_version !== undefined && event.state_version > stateVersion.current) {
+          stateVersion.current = event.state_version;
         }
+      } else if (
+        event.type === 'task/status' &&
+        (event.status === 'completed' || event.status === 'failed' || event.status === 'stopped')
+      ) {
+        processedRequestIds.current.clear();
+        pendingTaskRef.current = {};
+      } else if (event.type === 'task/status' && event.status === 'has_question') {
+        pendingTaskRef.current = {};
+      } else if (event.type === 'task/status' && event.status === 'running') {
+        pendingTaskRef.current = {
+          ...pendingTaskRef.current,
+          agentRunning: true,
+          apiTaskId: pendingTaskRef.current.apiTaskId || event.task_id || undefined,
+        };
+        maybeActivateTask();
+        return;
+      }
 
-        updateProgressForTool(toolName, explanation, 'in_progress');
+      let effects: SseEffect[] = [];
+      commit(state => {
+        const result = reduceSse(state, event, currentModeRef.current);
+        effects = result.effects;
+        return result.state;
+      });
+      runEffects(effects);
 
-        const result = await toolExecutionService.executeTool(toolName, args, mode, explanation);
-
-        if (result.success) {
-          try {
-            stateVersion.current++;
-            wsClient
-              .send({
-                type: 'tool/response',
-                call_id: requestId,
-                success: true,
-                data: typeof result.data === 'string' ? result.data : JSON.stringify(result.data),
-                state_version: stateVersion.current,
-              })
-              .catch(err => console.error('Failed to send tool success response:', err));
-            updateProgressForTool(toolName, explanation, 'completed');
-
-            if (toolName === 'done') {
-              pendingTaskRef.current = {};
-              setTaskState_(prev => {
-                chatService.setTaskState(false, null, []);
-                isTaskRunningRef.current = false;
-                setMessages(msgPrev => {
-                  const found = findMessageForProgress({
-                    messages: msgPrev.messages,
-                    isTaskRunning: prev.isTaskRunning,
-                    currentMode: currentModeRef.current,
-                    requireContent: false,
-                  });
-                  const newMessages = [...msgPrev.messages];
-                  if (found) {
-                    const updatedParts = (found.message.parts ?? []).filter(
-                      part => !(part.type === 'progress' && part.toolName === 'done'),
-                    );
-                    newMessages[found.index] = { ...found.message, taskStatus: 'done', parts: updatedParts };
-                    chatService.setMessages(newMessages);
-                  }
-                  return { messages: newMessages };
-                });
-                return { ...prev, isTaskRunning: false, activeTaskId: null, taskProgress: [] };
-              });
-            }
-          } catch (error) {
-            console.error('Failed to send tool result:', error);
-            updateProgressForTool(toolName, explanation, 'failed', 'Connection error');
-          }
-        } else {
-          updateProgressForTool(toolName, explanation, 'failed', result.error || 'Tool execution failed');
-          stateVersion.current++;
-          wsClient
-            .send({
-              type: 'tool/response',
-              call_id: requestId,
-              success: false,
-              data: typeof result.data === 'string' ? result.data : JSON.stringify(result.data),
-              error: result.error ?? undefined,
-              state_version: stateVersion.current,
-            })
-            .catch(err => console.error('Failed to send tool error response:', err));
-        }
-      } else if (event.type === 'task/status') {
-        const status = event.status;
-        const statusMessage = event.message || '';
-
-        if (status === 'running') {
-          // 'running' is the canonical in-progress wire status.
-          pendingTaskRef.current = {
-            ...pendingTaskRef.current,
-            agentRunning: true,
-            apiTaskId: pendingTaskRef.current.apiTaskId || event.task_id || undefined,
-          };
-          maybeActivateTask();
-        } else if (status === 'has_question') {
-          // Task is paused awaiting a user answer — not terminal. Stop the running
-          // spinner and flip the active message to the "waiting for you" indicator,
-          // but leave taskStatus unset (no done/failed icon) so a follow-up answer can resume.
-          pendingTaskRef.current = {};
-          setTaskState_(prev => {
-            chatService.setTaskState(false, null, []);
-            setMessages(msgPrev => {
-              const found = findMessageForProgress({
-                messages: msgPrev.messages,
-                isTaskRunning: prev.isTaskRunning,
-                currentMode: currentModeRef.current,
-                requireContent: false,
-              });
-              const newMessages = [...msgPrev.messages];
-              if (found) {
-                const cleared = updateThinkingMarker(found.message, false, currentModeRef.current);
-                newMessages[found.index] = {
-                  ...cleared,
-                  placeholderState: 'waiting-for-user',
-                  ...(statusMessage && { content: statusMessage }),
-                };
-                chatService.setMessages(newMessages);
-              }
-              return { messages: newMessages };
-            });
-            isTaskRunningRef.current = false;
-            return { ...prev, isTaskRunning: false, activeTaskId: null, taskProgress: [] };
-          });
-        } else if (status === 'completed' || status === 'failed' || status === 'stopped') {
-          processedRequestIds.current.clear();
-          pendingTaskRef.current = {};
-          setTaskState_(prev => {
-            chatService.setTaskState(false, null, []);
-            setMessages(msgPrev => {
-              const found = findMessageForProgress({
-                messages: msgPrev.messages,
-                isTaskRunning: prev.isTaskRunning,
-                currentMode: currentModeRef.current,
-                requireContent: false,
-              });
-              const newMessages = [...msgPrev.messages];
-              if (found) {
-                let taskStatus: 'done' | 'failed' | 'stopped' = 'done';
-                if (status === 'failed') taskStatus = 'failed';
-                else if (status === 'stopped') taskStatus = 'stopped';
-                newMessages[found.index] = {
-                  ...found.message,
-                  taskStatus,
-                  ...(statusMessage && { content: statusMessage }),
-                };
-                chatService.setMessages(newMessages);
-              }
-              return { messages: newMessages };
-            });
-            isTaskRunningRef.current = false;
-            return { ...prev, isTaskRunning: false, activeTaskId: null, taskProgress: [] };
-          });
-        }
-      } else if (event.type === 'chat/response') {
-        setMessages(prev => {
-          const newMessages = prev.messages.map(msg => {
-            if (msg.id !== event.request_id) return msg;
-            const newParts = [...(msg.parts ?? []), { type: 'text' as const, content: event.text }];
-            return {
-              ...msg,
-              content: event.text,
-              isPlaceholder: false,
-              placeholderState: undefined,
-              parts: newParts,
-              ...(event.task_id && { taskId: event.task_id }),
-            };
-          });
-          chatService.setMessages(newMessages);
-
-          if (event.task_id) {
-            pendingTaskRef.current = { ...pendingTaskRef.current, apiTaskId: event.task_id };
-            maybeActivateTask();
-          }
-
-          return { messages: newMessages };
-        });
-        uiActions.setLoading(false);
-      } else if (event.type === 'chat/error') {
-        setMessages(prev => {
-          const newMessages = prev.messages.map(msg => {
-            if (msg.id !== event.request_id) return msg;
-            const errorMessage = `Error: ${event.error}`;
-            const newParts = [...(msg.parts ?? []), { type: 'text' as const, content: errorMessage }];
-            return {
-              ...msg,
-              content: errorMessage,
-              isPlaceholder: false,
-              placeholderState: undefined,
-              parts: newParts,
-            };
-          });
-          chatService.setMessages(newMessages);
-          return { messages: newMessages };
-        });
-        uiActions.setLoading(false);
+      const toolCall = effects.find(e => e.type === 'executeTool');
+      if (toolCall?.type === 'executeTool') {
+        await executeToolCall(toolCall);
       }
     };
 
@@ -410,7 +278,7 @@ export const TaskProvider: React.FC<TaskProviderProps> = ({
     return () => {
       wsClient.removeCallbacks(callbacks);
     };
-  }, [previewMode, updateProgressForTool, maybeActivateTask, addProcessedRequestId, setMessages, uiActions]);
+  }, [previewMode, commit, maybeActivateTask, addProcessedRequestId, uiActions]);
 
   // -------------------------------------------------------------------------
   // Public actions
@@ -418,8 +286,9 @@ export const TaskProvider: React.FC<TaskProviderProps> = ({
   const setTaskStateAction = useCallback(
     (payload: { activeTaskId: string | null; isTaskRunning: boolean; taskProgress?: TaskProgress[] }) => {
       setTaskState_(prev => {
-        chatService.setTaskState(payload.isTaskRunning, payload.activeTaskId, payload.taskProgress ?? []);
-        return { ...prev, ...payload };
+        const next = { ...prev, ...payload };
+        taskRef.current = next;
+        return next;
       });
     },
     [],
@@ -427,34 +296,14 @@ export const TaskProvider: React.FC<TaskProviderProps> = ({
 
   const stopTask = useCallback(async () => {
     const taskId = activeTaskIdRef.current ?? undefined;
-
-    setTaskState_(prev => {
-      setMessages(msgPrev => {
-        const found = findMessageForProgress({
-          messages: msgPrev.messages,
-          isTaskRunning: prev.isTaskRunning,
-          currentMode: currentModeRef.current,
-          requireContent: false,
-        });
-        const newMessages = [...msgPrev.messages];
-        if (found) {
-          newMessages[found.index] = { ...found.message, taskStatus: 'stopped' };
-          if (!previewMode) chatService.setMessages(newMessages);
-        }
-        return { messages: newMessages };
-      });
-
-      if (!previewMode) chatService.setTaskState(false, null, []);
-      isTaskRunningRef.current = false;
-      return { ...prev, isTaskRunning: false, activeTaskId: null, taskProgress: [] };
-    });
+    commit(s => reduceStop(s, currentModeRef.current));
 
     if (previewMode) return;
 
     StreamClient.getInstance()
       .send({ type: 'chat/stop' as const, ...(taskId && { task_id: taskId }) })
       .catch(err => console.error('Failed to stop task remotely:', err));
-  }, [previewMode, setMessages, activeTaskIdRef]);
+  }, [previewMode, commit, activeTaskIdRef]);
 
   const taskActions = useMemo<TaskActions>(
     () => ({ setTaskState: setTaskStateAction, stopTask }),

--- a/src/context/UIStateContext.tsx
+++ b/src/context/UIStateContext.tsx
@@ -1,6 +1,5 @@
 import React, { createContext, useContext, useMemo, useState } from 'react';
 
-import { chatService } from '../services/ChatService';
 import type { InstructionType, WidgetView } from '../types';
 
 // ---------------------------------------------------------------------------
@@ -72,33 +71,17 @@ export const UIStateProvider: React.FC<UIStateProviderProps> = ({
       setActiveView: (view: WidgetView) => setUIState(prev => ({ ...prev, activeView: view })),
 
       toggleWidget: () =>
-        setUIState(prev => {
-          const newState = {
-            ...prev,
-            isOpen: !prev.isOpen,
-            isMinimized: !prev.isOpen ? false : true,
-          };
-          chatService.setWidgetState(newState.isOpen, newState.isMinimized);
-          return newState;
-        }),
+        setUIState(prev => ({
+          ...prev,
+          isOpen: !prev.isOpen,
+          isMinimized: !prev.isOpen ? false : true,
+        })),
 
-      closeWidget: () =>
-        setUIState(prev => {
-          const newState = { ...prev, isOpen: false, isMinimized: true };
-          chatService.setWidgetState(newState.isOpen, newState.isMinimized);
-          return newState;
-        }),
+      closeWidget: () => setUIState(prev => ({ ...prev, isOpen: false, isMinimized: true })),
 
-      setMode: (mode: InstructionType) =>
-        setUIState(prev => {
-          chatService.setMode(mode);
-          return { ...prev, currentMode: mode };
-        }),
+      setMode: (mode: InstructionType) => setUIState(prev => ({ ...prev, currentMode: mode })),
 
-      setLoading: (loading: boolean) => {
-        chatService.setIsLoading(loading);
-        setUIState(prev => ({ ...prev, isLoading: loading }));
-      },
+      setLoading: (loading: boolean) => setUIState(prev => ({ ...prev, isLoading: loading })),
 
       setAgentAvailable: (available: boolean) => setUIState(prev => ({ ...prev, agentAvailable: available })),
 

--- a/src/context/WidgetProviders.tsx
+++ b/src/context/WidgetProviders.tsx
@@ -2,8 +2,10 @@
  * WidgetProviders — composition root that wires UIStateProvider, ChatProvider,
  * and TaskProvider together.
  *
- * Initialization logic (SSE connection, ChatService hydration) lives in the
- * inner bridge component which has access to all three contexts.
+ * Initialization (SSE connection, ChatService hydration) and persistence both
+ * live in inner bridge components that have access to all three contexts.
+ * React context is the single source of truth; ChatService is the load/persist
+ * boundary only, driven by one effect here.
  */
 import React, { useEffect, useRef } from 'react';
 
@@ -11,9 +13,46 @@ import { chatService } from '../services/ChatService';
 import { configManager } from '../services/ConfigManager';
 import { sessionManager } from '../services/SessionManager';
 import { StreamClient } from '../services/StreamClient';
-import { ChatProvider, useChatContextInternal } from './ChatContext';
-import { TaskProvider } from './TaskContext';
+import type { ChatMessage } from '../types';
+import { ChatProvider, useChatContext, useChatContextInternal } from './ChatContext';
+import { TaskProvider, useTaskContext } from './TaskContext';
 import { UIStateProvider, useUIStateContext } from './UIStateContext';
+
+// ---------------------------------------------------------------------------
+// Persistence bridge — single context → storage effect (innermost, sees all)
+// ---------------------------------------------------------------------------
+
+const PersistBridge: React.FC<{ previewMode: boolean }> = ({ previewMode }) => {
+  const { uiState } = useUIStateContext();
+  const { chatState } = useChatContext();
+  const { taskState } = useTaskContext();
+
+  useEffect(() => {
+    if (previewMode) return;
+    chatService.persist({
+      messages: chatState.messages,
+      isTaskRunning: taskState.isTaskRunning,
+      activeTaskId: taskState.activeTaskId,
+      taskProgress: taskState.taskProgress,
+      currentMode: uiState.currentMode,
+      isOpen: uiState.isOpen,
+      isMinimized: uiState.isMinimized,
+      isLoading: uiState.isLoading,
+    });
+  }, [
+    previewMode,
+    chatState.messages,
+    taskState.isTaskRunning,
+    taskState.activeTaskId,
+    taskState.taskProgress,
+    uiState.currentMode,
+    uiState.isOpen,
+    uiState.isMinimized,
+    uiState.isLoading,
+  ]);
+
+  return null;
+};
 
 // ---------------------------------------------------------------------------
 // Inner bridge — has access to UIState and Chat, mounts TaskProvider
@@ -30,6 +69,8 @@ const TaskBridge: React.FC<BridgeProps> = ({ children, previewMode }) => {
 
   // Stable ref so TaskProvider's stopTask never stale-closes over activeTaskId
   const activeTaskIdRef = useRef<string | null>(null);
+  // Live messages snapshot the SSE reducer wiring reads without stale closures
+  const messagesRef = useRef<ChatMessage[]>([]);
 
   // -------------------------------------------------------------------------
   // One-time initialization: hydrate from ChatService + connect stream
@@ -48,22 +89,22 @@ const TaskBridge: React.FC<BridgeProps> = ({ children, previewMode }) => {
 
       chatService.initialize(chatId);
 
-      const isTaskRunning = chatService.getIsTaskRunning();
-      const activeTaskId = chatService.getActiveTaskId();
+      const snapshot = chatService.restore();
 
-      // Hydrate UIState from persisted ChatService values
+      // Hydrate UIState from persisted snapshot
       uiActions.applyState({
-        isLoading: chatService.getIsLoading(),
-        currentMode: chatService.getCurrentMode(),
-        isOpen: chatService.getIsOpen(),
-        isMinimized: chatService.getIsMinimized(),
+        isLoading: snapshot.isLoading,
+        currentMode: snapshot.currentMode,
+        isOpen: snapshot.isOpen,
+        isMinimized: snapshot.isMinimized,
       });
 
       // Hydrate ChatState
-      _setMessages({ messages: chatService.getMessages() });
+      messagesRef.current = snapshot.messages;
+      _setMessages({ messages: snapshot.messages });
 
       // Hydrate activeTaskId ref
-      activeTaskIdRef.current = isTaskRunning ? activeTaskId : null;
+      activeTaskIdRef.current = snapshot.isTaskRunning ? snapshot.activeTaskId : null;
 
       // Connect SSE stream
       if (chatId) {
@@ -94,10 +135,12 @@ const TaskBridge: React.FC<BridgeProps> = ({ children, previewMode }) => {
       previewMode={previewMode}
       currentMode={uiState.currentMode}
       setMessages={_setMessages}
+      messagesRef={messagesRef}
       uiActions={uiActions}
       activeTaskIdRef={activeTaskIdRef}
     >
       {children}
+      <PersistBridge previewMode={previewMode} />
     </TaskProvider>
   );
 };

--- a/src/context/__tests__/sseReducer.test.ts
+++ b/src/context/__tests__/sseReducer.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Unit tests for the pure SSE reducer (src/context/sseReducer.ts).
+ * These pin the state-transition behavior the TaskContext effect used to bury
+ * inside a ~180-line nested-setState handler.
+ */
+import { describe, expect, it } from 'vitest';
+
+import type { WidgetEvent } from '@/sdk/schema';
+import type { ChatMessage } from '@/types';
+import { hasThinkingMarker } from '@/utils/chat';
+
+import { reduceSse, reduceStop, reduceToolDone, reduceToolProgress, type SseState } from '../sseReducer';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const agentMessage = (overrides: Partial<ChatMessage> = {}): ChatMessage => ({
+  id: 'agent-1',
+  content: 'Working on it\n\n__THINKING__',
+  sender: 'agent',
+  timestamp: new Date(),
+  mode: 'do',
+  isPlaceholder: true,
+  placeholderState: 'thinking',
+  parts: [{ type: 'text', content: 'Working on it' }],
+  ...overrides,
+});
+
+const runningState = (overrides: Partial<ChatMessage> = {}): SseState => ({
+  messages: [agentMessage(overrides)],
+  task: { activeTaskId: 'task-1', isTaskRunning: true },
+});
+
+const idleState = (): SseState => ({
+  messages: [agentMessage({ placeholderState: undefined })],
+  task: { activeTaskId: null, isTaskRunning: false },
+});
+
+// ---------------------------------------------------------------------------
+// task/status
+// ---------------------------------------------------------------------------
+
+describe('reduceSse — task/status', () => {
+  it('running is a pure no-op — activation is gated on pendingTaskRef in the wiring', () => {
+    const state = idleState();
+    const event: WidgetEvent = { type: 'task/status', status: 'running', task_id: 'task-9' };
+    const result = reduceSse(state, event, 'do');
+    expect(result.state).toBe(state);
+    expect(result.effects).toEqual([]);
+  });
+
+  it('running without task_id is also a no-op', () => {
+    const state = idleState();
+    const result = reduceSse(state, { type: 'task/status', status: 'running' }, 'do');
+    expect(result.state).toBe(state);
+    expect(result.effects).toEqual([]);
+  });
+
+  it('completed ends the task and marks the active message done', () => {
+    const result = reduceSse(runningState(), { type: 'task/status', status: 'completed' }, 'do');
+    expect(result.state.task).toEqual({ isTaskRunning: false, activeTaskId: null });
+    expect(result.state.messages[0].taskStatus).toBe('done');
+  });
+
+  it('failed ends the task and marks the active message failed', () => {
+    const result = reduceSse(runningState(), { type: 'task/status', status: 'failed' }, 'do');
+    expect(result.state.task.isTaskRunning).toBe(false);
+    expect(result.state.messages[0].taskStatus).toBe('failed');
+  });
+
+  it('stopped ends the task and marks the active message stopped', () => {
+    const result = reduceSse(runningState(), { type: 'task/status', status: 'stopped' }, 'do');
+    expect(result.state.task.isTaskRunning).toBe(false);
+    expect(result.state.messages[0].taskStatus).toBe('stopped');
+  });
+
+  it('terminal status overwrites content when the event carries a message', () => {
+    const event: WidgetEvent = { type: 'task/status', status: 'completed', message: 'All done!' };
+    const result = reduceSse(runningState(), event, 'do');
+    expect(result.state.messages[0].content).toBe('All done!');
+  });
+
+  it('has_question pauses (not terminal): clears spinner, flips to waiting-for-user, no taskStatus', () => {
+    const before = runningState();
+    expect(hasThinkingMarker(before.messages[0].content)).toBe(true);
+
+    const event: WidgetEvent = { type: 'task/status', status: 'has_question', message: 'Which account?' };
+    const result = reduceSse(before, event, 'do');
+
+    const msg = result.state.messages[0];
+    expect(hasThinkingMarker(msg.content)).toBe(false);
+    expect(msg.placeholderState).toBe('waiting-for-user');
+    expect(msg.content).toContain('Which account?');
+    // Paused, not finished — no terminal icon.
+    expect(msg.taskStatus).toBeUndefined();
+    expect(result.state.task).toEqual({ isTaskRunning: false, activeTaskId: null });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tool/call
+// ---------------------------------------------------------------------------
+
+describe('reduceSse — tool/call', () => {
+  const toolCall = (overrides: Partial<Extract<WidgetEvent, { type: 'tool/call' }>> = {}): WidgetEvent => ({
+    type: 'tool/call',
+    call_id: 'call-1',
+    tool: 'click_element',
+    args: { index: 1 },
+    explanation: 'Clicking the submit button',
+    ...overrides,
+  });
+
+  it('emits an executeTool effect carrying the call details', () => {
+    const result = reduceSse(runningState(), toolCall(), 'do');
+    expect(result.effects).toEqual([
+      {
+        type: 'executeTool',
+        callId: 'call-1',
+        tool: 'click_element',
+        args: { index: 1 },
+        mode: 'do',
+        explanation: 'Clicking the submit button',
+      },
+    ]);
+  });
+
+  it('auto-activates the task when a tool arrives before task/status running', () => {
+    const result = reduceSse(idleState(), toolCall(), 'do');
+    expect(result.state.task.isTaskRunning).toBe(true);
+  });
+
+  it('adds an in-progress progress line to the active message', () => {
+    const result = reduceSse(runningState(), toolCall(), 'do');
+    const progressParts = (result.state.messages[0].parts ?? []).filter(p => p.type === 'progress');
+    expect(progressParts).toHaveLength(1);
+    expect(progressParts[0].status).toBe('in_progress');
+  });
+
+  it('falls back to event.mode then "do" when currentMode is absent on the call', () => {
+    const result = reduceSse(runningState(), toolCall({ mode: 'show' }), 'show');
+    const effect = result.effects[0];
+    expect(effect.type === 'executeTool' && effect.mode).toBe('show');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// chat/response & chat/error
+// ---------------------------------------------------------------------------
+
+describe('reduceSse — chat/response', () => {
+  it('resolves the matching placeholder and turns off loading', () => {
+    const state: SseState = {
+      messages: [agentMessage({ id: 'req-1', content: '\n\n__THINKING__', parts: [] })],
+      task: { activeTaskId: null, isTaskRunning: false },
+    };
+    const event: WidgetEvent = { type: 'chat/response', request_id: 'req-1', text: 'Here you go' };
+    const result = reduceSse(state, event, 'tell');
+
+    const msg = result.state.messages[0];
+    expect(msg.content).toBe('Here you go');
+    expect(msg.isPlaceholder).toBe(false);
+    expect(msg.placeholderState).toBeUndefined();
+    expect(msg.parts?.at(-1)).toEqual({ type: 'text', content: 'Here you go' });
+    expect(result.effects).toContainEqual({ type: 'setLoading', value: false });
+  });
+
+  it('adds an activateApiTask effect when the response carries a task_id', () => {
+    const state: SseState = {
+      messages: [agentMessage({ id: 'req-1' })],
+      task: { activeTaskId: null, isTaskRunning: false },
+    };
+    const event: WidgetEvent = { type: 'chat/response', request_id: 'req-1', text: 'ok', task_id: 'task-7' };
+    const result = reduceSse(state, event, 'tell');
+    expect(result.effects).toContainEqual({ type: 'activateApiTask', taskId: 'task-7' });
+  });
+});
+
+describe('reduceSse — chat/error', () => {
+  it('writes an error message into the matching placeholder and turns off loading', () => {
+    const state: SseState = {
+      messages: [agentMessage({ id: 'req-2' })],
+      task: { activeTaskId: null, isTaskRunning: false },
+    };
+    const event: WidgetEvent = { type: 'chat/error', request_id: 'req-2', error: 'boom' };
+    const result = reduceSse(state, event, 'tell');
+    expect(result.state.messages[0].content).toBe('Error: boom');
+    expect(result.state.messages[0].isPlaceholder).toBe(false);
+    expect(result.effects).toEqual([{ type: 'setLoading', value: false }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unknown / non-stateful events
+// ---------------------------------------------------------------------------
+
+describe('reduceSse — ignored events', () => {
+  it.each(['registered', 'pong', 'heartbeat'] as const)('%s is a no-op (same state, no effects)', type => {
+    const state = runningState();
+    const event = { type, chat_id: 'c1' } as unknown as WidgetEvent;
+    const result = reduceSse(state, event, 'do');
+    expect(result.state).toBe(state);
+    expect(result.effects).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tool lifecycle helpers
+// ---------------------------------------------------------------------------
+
+describe('reduceToolProgress / reduceToolDone / reduceStop', () => {
+  it('completed marks the in-progress line complete', () => {
+    const inProgress = reduceSse(
+      runningState(),
+      {
+        type: 'tool/call',
+        call_id: 'c',
+        tool: 'click_element',
+        args: {},
+        explanation: 'x',
+      },
+      'do',
+    ).state;
+    const done = reduceToolProgress(inProgress, 'click_element', 'x', 'completed', 'do');
+    const part = (done.messages[0].parts ?? []).find(p => p.type === 'progress');
+    expect(part?.status).toBe('completed');
+  });
+
+  it('failed marks the line failed and surfaces the error text', () => {
+    const inProgress = reduceSse(
+      runningState(),
+      {
+        type: 'tool/call',
+        call_id: 'c',
+        tool: 'click_element',
+        args: {},
+        explanation: 'Clicking',
+      },
+      'do',
+    ).state;
+    const failed = reduceToolProgress(inProgress, 'click_element', 'Clicking', 'failed', 'do', 'no element');
+    const part = (failed.messages[0].parts ?? []).find(p => p.type === 'progress');
+    expect(part?.status).toBe('failed');
+    expect(part?.content).toContain('no element');
+  });
+
+  it('reduceToolDone ends the task, marks done, and strips the lingering done progress line', () => {
+    const withDoneLine: SseState = {
+      messages: [
+        agentMessage({
+          parts: [
+            { type: 'text', content: 'Working on it' },
+            { type: 'progress', content: 'Finishing', status: 'in_progress', toolName: 'done' },
+          ],
+        }),
+      ],
+      task: { activeTaskId: 'task-1', isTaskRunning: true },
+    };
+    const result = reduceToolDone(withDoneLine, 'do');
+    expect(result.task).toEqual({ isTaskRunning: false, activeTaskId: null });
+    expect(result.messages[0].taskStatus).toBe('done');
+    expect((result.messages[0].parts ?? []).some(p => p.type === 'progress' && p.toolName === 'done')).toBe(false);
+  });
+
+  it('reduceStop marks the active message stopped and ends the task', () => {
+    const result = reduceStop(runningState(), 'do');
+    expect(result.messages[0].taskStatus).toBe('stopped');
+    expect(result.task).toEqual({ isTaskRunning: false, activeTaskId: null });
+  });
+});

--- a/src/context/sseReducer.ts
+++ b/src/context/sseReducer.ts
@@ -1,0 +1,272 @@
+/**
+ * Pure SSE reducer — the single place where a `WidgetEvent` turns into the next
+ * widget state. No transport, no tool execution, no localStorage: just
+ * `(state, event) => { state, effects }`. The TaskContext effect wires this up,
+ * runs the returned effects (tool exec, wsClient.send, setLoading), and re-enters
+ * via `applyToolResult` once an async tool finishes.
+ *
+ * Keeping this pure makes the previously-untestable ~180-line SSE handler unit
+ * testable and removes the nested setState-within-setState that hid bugs.
+ */
+import type { WidgetEvent } from '../sdk/schema';
+import type { ChatMessage, InstructionType } from '../types';
+import {
+  addProgressLine,
+  findMessageForProgress,
+  getFriendlyToolName,
+  markProgressLineComplete,
+  markProgressLineFailed,
+  updateThinkingMarker,
+  WAIT_FOR_USER_TOOLS,
+} from '../utils/chat';
+
+export interface SseTaskState {
+  activeTaskId: string | null;
+  isTaskRunning: boolean;
+}
+
+export interface SseState {
+  messages: ChatMessage[];
+  task: SseTaskState;
+}
+
+/** Side effects the wiring layer must run after applying a reduced state. */
+export type SseEffect =
+  | {
+      type: 'executeTool';
+      callId: string;
+      tool: string;
+      args: Record<string, unknown>;
+      mode: InstructionType;
+      explanation: string;
+    }
+  | { type: 'setLoading'; value: boolean }
+  | { type: 'activateApiTask'; taskId: string };
+
+export interface ReduceResult {
+  state: SseState;
+  effects: SseEffect[];
+}
+
+const noChange = (state: SseState): ReduceResult => ({ state, effects: [] });
+
+type ProgressStatus = 'in_progress' | 'completed' | 'failed';
+
+/**
+ * Apply a progress-line transition to the message that owns the active task.
+ * Mirrors the original `updateProgressForTool` body verbatim.
+ */
+function applyProgress(
+  messages: ChatMessage[],
+  isTaskRunning: boolean,
+  currentMode: InstructionType,
+  toolName: string,
+  explanation: string,
+  status: ProgressStatus,
+  error?: string,
+): ChatMessage[] {
+  const friendlyName = getFriendlyToolName(toolName);
+  const found = findMessageForProgress({
+    messages,
+    isTaskRunning,
+    currentMode,
+    requireContent: status === 'failed',
+  });
+  if (!found) return messages;
+
+  let updatedMsg = found.message;
+  const shouldWait = isTaskRunning && currentMode === 'show' && WAIT_FOR_USER_TOOLS.has(toolName);
+  const isDoneTool = toolName === 'done';
+  const isShowOrDo = currentMode === 'show' || currentMode === 'do';
+
+  if (status === 'in_progress') {
+    if (!isDoneTool) {
+      updatedMsg = addProgressLine(updatedMsg, friendlyName, explanation || friendlyName);
+    }
+    if (isTaskRunning && isShowOrDo) {
+      updatedMsg = updateThinkingMarker(updatedMsg, isTaskRunning, currentMode, shouldWait);
+    }
+  } else if (status === 'completed') {
+    if (!isDoneTool) {
+      updatedMsg = markProgressLineComplete(updatedMsg);
+    }
+    if (isTaskRunning && isShowOrDo) {
+      updatedMsg = updateThinkingMarker(updatedMsg, isTaskRunning, currentMode, false);
+    }
+  } else {
+    updatedMsg = markProgressLineFailed(updatedMsg, friendlyName, error || '');
+    if (isTaskRunning && isShowOrDo) {
+      updatedMsg = updateThinkingMarker(updatedMsg, isTaskRunning, currentMode, false);
+    }
+  }
+
+  const next = [...messages];
+  next[found.index] = updatedMsg;
+  return next;
+}
+
+/** Public: progress transition used by the wiring layer for tool lifecycle. */
+export function reduceToolProgress(
+  state: SseState,
+  toolName: string,
+  explanation: string,
+  status: ProgressStatus,
+  currentMode: InstructionType,
+  error?: string,
+): SseState {
+  return {
+    ...state,
+    messages: applyProgress(
+      state.messages,
+      state.task.isTaskRunning,
+      currentMode,
+      toolName,
+      explanation,
+      status,
+      error,
+    ),
+  };
+}
+
+/** Public: terminal `done` tool — strip the in-flight `done` progress line and end the task. */
+export function reduceToolDone(state: SseState, currentMode: InstructionType): SseState {
+  const found = findMessageForProgress({
+    messages: state.messages,
+    isTaskRunning: state.task.isTaskRunning,
+    currentMode,
+    requireContent: false,
+  });
+  const messages = [...state.messages];
+  if (found) {
+    const updatedParts = (found.message.parts ?? []).filter(
+      part => !(part.type === 'progress' && part.toolName === 'done'),
+    );
+    messages[found.index] = { ...found.message, taskStatus: 'done', parts: updatedParts };
+  }
+  return { messages, task: { isTaskRunning: false, activeTaskId: null } };
+}
+
+/** Public: user-initiated stop — flag the active message `stopped` and end the task. */
+export function reduceStop(state: SseState, currentMode: InstructionType): SseState {
+  const found = findMessageForProgress({
+    messages: state.messages,
+    isTaskRunning: state.task.isTaskRunning,
+    currentMode,
+    requireContent: false,
+  });
+  const messages = [...state.messages];
+  if (found) {
+    messages[found.index] = { ...found.message, taskStatus: 'stopped' };
+  }
+  return { messages, task: { isTaskRunning: false, activeTaskId: null } };
+}
+
+/**
+ * Pure reducer. Returns the next state plus any side effects the wiring must run.
+ * Unknown / non-stateful events (registered, pong, heartbeat) are ignored.
+ */
+export function reduceSse(state: SseState, event: WidgetEvent, currentMode: InstructionType): ReduceResult {
+  switch (event.type) {
+    case 'tool/call': {
+      // Auto-activate the task if a tool arrives before `task/status running`.
+      const task = state.task.isTaskRunning ? state.task : { ...state.task, isTaskRunning: true };
+      const isTaskRunning = task.isTaskRunning;
+      const mode = event.mode || currentMode || 'do';
+      const explanation = event.explanation || '';
+      const messages = applyProgress(
+        state.messages,
+        isTaskRunning,
+        currentMode,
+        event.tool,
+        explanation,
+        'in_progress',
+      );
+      return {
+        state: { messages, task },
+        effects: [
+          { type: 'executeTool', callId: event.call_id, tool: event.tool, args: event.args, mode, explanation },
+        ],
+      };
+    }
+
+    case 'task/status': {
+      const statusMessage = event.message || '';
+      if (event.status === 'running') {
+        // Activation is gated on both the API task_id and `agentRunning` being
+        // present — that bookkeeping lives in the wiring (pendingTaskRef), so the
+        // pure reducer leaves state untouched here.
+        return noChange(state);
+      }
+      if (event.status === 'has_question') {
+        // Paused awaiting a user answer — not terminal. Stop the spinner and flip
+        // the active message to "waiting for you", leaving taskStatus unset.
+        const found = findMessageForProgress({
+          messages: state.messages,
+          isTaskRunning: state.task.isTaskRunning,
+          currentMode,
+          requireContent: false,
+        });
+        const messages = [...state.messages];
+        if (found) {
+          const cleared = updateThinkingMarker(found.message, false, currentMode);
+          messages[found.index] = {
+            ...cleared,
+            placeholderState: 'waiting-for-user',
+            ...(statusMessage && { content: statusMessage }),
+          };
+        }
+        return { state: { messages, task: { isTaskRunning: false, activeTaskId: null } }, effects: [] };
+      }
+      // completed | failed | stopped — terminal.
+      const found = findMessageForProgress({
+        messages: state.messages,
+        isTaskRunning: state.task.isTaskRunning,
+        currentMode,
+        requireContent: false,
+      });
+      const messages = [...state.messages];
+      if (found) {
+        let taskStatus: 'done' | 'failed' | 'stopped' = 'done';
+        if (event.status === 'failed') taskStatus = 'failed';
+        else if (event.status === 'stopped') taskStatus = 'stopped';
+        messages[found.index] = {
+          ...found.message,
+          taskStatus,
+          ...(statusMessage && { content: statusMessage }),
+        };
+      }
+      return { state: { messages, task: { isTaskRunning: false, activeTaskId: null } }, effects: [] };
+    }
+
+    case 'chat/response': {
+      const messages = state.messages.map(msg => {
+        if (msg.id !== event.request_id) return msg;
+        const newParts = [...(msg.parts ?? []), { type: 'text' as const, content: event.text }];
+        return {
+          ...msg,
+          content: event.text,
+          isPlaceholder: false,
+          placeholderState: undefined,
+          parts: newParts,
+          ...(event.task_id && { taskId: event.task_id }),
+        };
+      });
+      const effects: SseEffect[] = [{ type: 'setLoading', value: false }];
+      if (event.task_id) effects.push({ type: 'activateApiTask', taskId: event.task_id });
+      return { state: { ...state, messages }, effects };
+    }
+
+    case 'chat/error': {
+      const messages = state.messages.map(msg => {
+        if (msg.id !== event.request_id) return msg;
+        const errorMessage = `Error: ${event.error}`;
+        const newParts = [...(msg.parts ?? []), { type: 'text' as const, content: errorMessage }];
+        return { ...msg, content: errorMessage, isPlaceholder: false, placeholderState: undefined, parts: newParts };
+      });
+      return { state: { ...state, messages }, effects: [{ type: 'setLoading', value: false }] };
+    }
+
+    default:
+      return noChange(state);
+  }
+}

--- a/src/services/ChatService.ts
+++ b/src/services/ChatService.ts
@@ -2,17 +2,32 @@ import type { ChatMessage, InstructionType, TaskProgress } from '../types';
 import { removeThinkingMarkers } from '../utils/chat';
 import { storageService } from './StorageService';
 
+/**
+ * Snapshot of widget state persisted to / restored from localStorage.
+ * React context is the single source of truth at runtime — this is the
+ * load/persist boundary only.
+ */
+export interface ChatSnapshot {
+  messages: ChatMessage[];
+  isTaskRunning: boolean;
+  activeTaskId: string | null;
+  taskProgress: TaskProgress[];
+  currentMode: InstructionType;
+  isOpen: boolean;
+  isMinimized: boolean;
+  isLoading: boolean;
+}
+
+/**
+ * ChatService — thin persistence layer.
+ *
+ * Owns only the localStorage read/write lifecycle for the widget chat context.
+ * It no longer mirrors runtime state; contexts call `persist(snapshot)` from a
+ * single effect and `restore()` once on mount.
+ */
 export class ChatService {
   private static instance: ChatService;
-  private messages: ChatMessage[] = [];
   private chatId: string | null = null;
-  private isTaskRunning: boolean = false;
-  private activeTaskId: string | null = null;
-  private taskProgress: TaskProgress[] = [];
-  private currentMode: InstructionType = 'tell';
-  private isOpen: boolean = false;
-  private isMinimized: boolean = false;
-  private isLoading: boolean = false;
   initError: Error | null = null;
 
   private constructor() {}
@@ -26,12 +41,10 @@ export class ChatService {
 
   initialize(chatId: string | null): void {
     this.chatId = chatId;
-    this.restoreState();
   }
 
   createInitialContext(chatId: string): void {
     try {
-      // Only create if no existing context
       if (storageService.hasValidContext()) {
         return;
       }
@@ -57,163 +70,70 @@ export class ChatService {
     return this.initError;
   }
 
-  getMessages(): ChatMessage[] {
-    return this.messages;
-  }
+  /** Read the persisted snapshot, rehydrating messages (dates, lost streams). */
+  restore(): ChatSnapshot {
+    const context = storageService.getContext();
 
-  getIsLoading(): boolean {
-    return this.isLoading;
-  }
-
-  getIsTaskRunning(): boolean {
-    return this.isTaskRunning;
-  }
-
-  getActiveTaskId(): string | null {
-    return this.activeTaskId;
-  }
-
-  getTaskProgress(): TaskProgress[] {
-    return this.taskProgress;
-  }
-
-  getCurrentMode(): InstructionType {
-    return this.currentMode;
-  }
-
-  getIsOpen(): boolean {
-    return this.isOpen;
-  }
-
-  getIsMinimized(): boolean {
-    return this.isMinimized;
-  }
-
-  addMessage(message: ChatMessage): void {
-    this.messages = [...this.messages, message];
-    this.persistState();
-  }
-
-  updateMessage(messageId: string, updates: Partial<ChatMessage>): void {
-    this.messages = this.messages.map(msg => (msg.id === messageId ? { ...msg, ...updates } : msg));
-    this.persistState();
-  }
-
-  removeMessage(messageId: string): void {
-    this.messages = this.messages.filter(msg => msg.id !== messageId);
-    this.persistState();
-  }
-
-  setMessages(messages: ChatMessage[]): void {
-    this.messages = messages;
-    this.persistState();
-  }
-
-  clearMessages(): void {
-    this.messages = [];
-    this.persistState();
-  }
-
-  setTaskState(isRunning: boolean, taskId: string | null, progress: TaskProgress[]): void {
-    this.isTaskRunning = isRunning;
-    this.activeTaskId = taskId;
-    this.taskProgress = progress;
-    this.persistState();
-  }
-
-  setMode(mode: InstructionType): void {
-    this.currentMode = mode;
-    this.persistState();
-  }
-
-  setWidgetState(isOpen: boolean, isMinimized: boolean): void {
-    this.isOpen = isOpen;
-    this.isMinimized = isMinimized;
-    this.persistState();
-  }
-
-  setIsLoading(loading: boolean): void {
-    this.isLoading = loading;
-    this.persistState();
-  }
-
-  // State Restoration & Persistence
-
-  private restoreState(): void {
-    try {
-      const context = storageService.getContext();
-
-      if (!context.chat_id) return;
-
-      if (this.chatId && context.chat_id !== this.chatId) {
-        // Chat ID mismatch - restoring history anyway
-      }
-
-      this.messages = context.messages.map(msg => {
-        // Handle restored screenshare messages
-        // If a message was a screenshare stream (id starts with 'screenshare-'),
-        // replace it with a "Screenshare ended" message since the stream is lost on refresh.
-        if (msg.id.startsWith('screenshare-')) {
-          return {
-            ...msg,
-            content: 'Screenshare ended',
-            videoStream: undefined,
-            isSystemMessage: true, // Treat as system message now
-            timestamp: new Date(msg.timestamp),
-            parts: [{ type: 'text', content: 'Screenshare ended' }],
-          };
-        }
-
-        const restoredMsg: ChatMessage = {
-          ...msg,
-          timestamp: new Date(msg.timestamp),
-          videoStream: undefined,
-          placeholderState: msg.placeholderState, // Restore placeholder state
-          taskStatus: msg.taskStatus, // Restore task status
-          parts: msg.parts || [], // Use stored parts or default to empty
-        };
-
-        // If no parts, create default text part from content (if any)
-        if (restoredMsg.parts?.length === 0 && restoredMsg.content) {
-          const cleanContent = restoredMsg.content.replace(/\n\n__THINKING__$/, '').trim();
-          if (cleanContent && restoredMsg.parts) {
-            restoredMsg.parts.push({
-              type: 'text',
-              content: cleanContent,
-            });
+    const messages: ChatMessage[] = context.chat_id
+      ? context.messages.map(msg => {
+          // A screenshare stream can't survive a reload — replace it with an
+          // "ended" system message rather than a dangling video placeholder.
+          if (msg.id.startsWith('screenshare-')) {
+            return {
+              ...msg,
+              content: 'Screenshare ended',
+              videoStream: undefined,
+              isSystemMessage: true,
+              timestamp: new Date(msg.timestamp),
+              parts: [{ type: 'text', content: 'Screenshare ended' }],
+            };
           }
-        }
 
-        return restoredMsg;
-      });
+          const restoredMsg: ChatMessage = {
+            ...msg,
+            timestamp: new Date(msg.timestamp),
+            videoStream: undefined,
+            placeholderState: msg.placeholderState,
+            taskStatus: msg.taskStatus,
+            parts: msg.parts || [],
+          };
 
-      this.isTaskRunning = context.isTaskRunning;
-      this.activeTaskId = context.activeTaskId;
-      this.taskProgress = context.taskProgress;
-      this.currentMode = context.currentMode;
-      this.isOpen = context.isOpen;
-      this.isMinimized = context.isMinimized;
-      this.isLoading = context.isLoading ?? false;
-    } catch (error) {
-      console.warn('[ChatService] Failed to restore state:', error);
-    }
+          if (restoredMsg.parts?.length === 0 && restoredMsg.content) {
+            const cleanContent = restoredMsg.content.replace(/\n\n__THINKING__$/, '').trim();
+            if (cleanContent && restoredMsg.parts) {
+              restoredMsg.parts.push({ type: 'text', content: cleanContent });
+            }
+          }
+
+          return restoredMsg;
+        })
+      : [];
+
+    return {
+      messages,
+      isTaskRunning: context.isTaskRunning,
+      activeTaskId: context.activeTaskId,
+      taskProgress: context.taskProgress,
+      currentMode: context.currentMode,
+      isOpen: context.isOpen,
+      isMinimized: context.isMinimized,
+      isLoading: context.isLoading ?? false,
+    };
   }
 
-  private persistState(): void {
+  /** Persist the current widget snapshot. No-op until a chatId is known. */
+  persist(snapshot: ChatSnapshot): void {
     if (!this.chatId) return;
 
     try {
-      const serializedMessages = this.messages
+      const serializedMessages = snapshot.messages
         .filter(msg => {
           if (!msg.isPlaceholder) return true;
-          // Keep placeholders if they have content, progress parts, OR are thinking/waiting
+          // Keep placeholders that are still thinking/waiting, or that carry parts.
           if (msg.placeholderState === 'thinking' || msg.placeholderState === 'waiting-for-user') {
             return true;
           }
-
-          // Only keep other placeholders if they have content or progress parts
-          const parts = msg.parts || [];
-          return parts.length > 0;
+          return (msg.parts || []).length > 0;
         })
         .filter(msg => !(msg.isSystemMessage && msg.content === 'Chat context changed'))
         .map(msg => ({
@@ -226,21 +146,21 @@ export class ChatService {
           screenShareStatus: msg.screenShareStatus,
           isSystemMessage: msg.isSystemMessage,
           isPlaceholder: msg.isPlaceholder,
-          placeholderState: msg.placeholderState, // Save placeholder state
-          taskStatus: msg.taskStatus, // Save task status
-          parts: msg.parts, // Save parts
+          placeholderState: msg.placeholderState,
+          taskStatus: msg.taskStatus,
+          parts: msg.parts,
         }));
 
       storageService.updateContext({
         chat_id: this.chatId,
         messages: serializedMessages,
-        isTaskRunning: this.isTaskRunning,
-        activeTaskId: this.activeTaskId,
-        taskProgress: this.taskProgress,
-        currentMode: this.currentMode,
-        isOpen: this.isOpen,
-        isMinimized: this.isMinimized,
-        isLoading: this.isLoading,
+        isTaskRunning: snapshot.isTaskRunning,
+        activeTaskId: snapshot.activeTaskId,
+        taskProgress: snapshot.taskProgress,
+        currentMode: snapshot.currentMode,
+        isOpen: snapshot.isOpen,
+        isMinimized: snapshot.isMinimized,
+        isLoading: snapshot.isLoading,
       });
     } catch (error) {
       console.warn('[ChatService] Failed to persist state:', error);

--- a/src/services/ToolService.ts
+++ b/src/services/ToolService.ts
@@ -1,3 +1,4 @@
+import { WAIT_FOR_USER_TOOLS } from '../utils/chat';
 import { domService } from './DomService';
 import { startScreenShare } from './ScreenShareService';
 import { showModeService } from './ShowModeService';
@@ -209,7 +210,7 @@ export class ToolExecutionService {
   }
 
   private requiresHighlight(toolName: string): boolean {
-    return ['click_element', 'type_text', 'select_dropdown_option', 'send_keys', 'upload_file'].includes(toolName);
+    return WAIT_FOR_USER_TOOLS.has(toolName);
   }
 
   private navigate(args: NavigateParams): ToolExecutionResult {

--- a/src/utils/chat.ts
+++ b/src/utils/chat.ts
@@ -266,13 +266,26 @@ function ensureMessageStructure(message: ChatMessage): ChatMessage {
  * These are "mouse and keyboard" interactions.
  * All other tools will have hidden icons and muted text.
  */
-const INTERACTIVE_TOOLS = new Set([
+export const INTERACTIVE_TOOLS = new Set([
   'click_element',
   'type_text',
   'send_keys',
   'select_dropdown_option',
   'upload_file',
   'scroll',
+]);
+
+/**
+ * Tools that, in `show` mode, pause for the user to perform the action
+ * themselves (DOM-mutating "mouse and keyboard" actions, minus `scroll`).
+ * Also the set that requires element highlighting in ToolService.
+ */
+export const WAIT_FOR_USER_TOOLS = new Set([
+  'click_element',
+  'type_text',
+  'select_dropdown_option',
+  'send_keys',
+  'upload_file',
 ]);
 
 /**


### PR DESCRIPTION
Closes #200

## What & why

The same task/message/UI state lived in **three** places — React context, the `chatService` singleton, and per-field localStorage — and every mutation wrote all three. That triple-write is the root of a class of "updated context but forgot the service" bugs. This makes **React context the single source of truth** and extracts a **pure, testable SSE reducer**. Behavior-preserving.

## What moved where

### Part A — `ChatService` becomes thin persistence
- **Removed** the mirrored fields (`messages` / `isTaskRunning` / `activeTaskId` / `taskProgress` / `currentMode` / `isOpen` / `isMinimized` / `isLoading`) and the write-only getters that were only read once at hydration.
- **Removed** every per-mutation setter (`addMessage`, `updateMessage`, `removeMessage`, `setMessages`, `clearMessages`, `setTaskState`, `setMode`, `setWidgetState`, `setIsLoading`) and the scattered `chatService.setX(...)` calls inside `ChatContext` / `TaskContext` / `UIStateContext`.
- ChatService now exposes `restore(): ChatSnapshot` (rehydrates dates, lost streams, screenshare-ended) and `persist(snapshot)`. Plus `initialize` / `createInitialContext` / `getInitError` and the message factory functions (unchanged).
- Persistence is now **one effect** — `PersistBridge` in `WidgetProviders` watches messages + task + UI state and calls `chatService.persist(...)` (skipped in `previewMode`). Restore-on-mount (history survives reload) is preserved.

### Part B — pure SSE reducer (`src/context/sseReducer.ts`)
- Extracted `reduceSse(state, event, currentMode) => { state, effects }` plus `reduceToolProgress` / `reduceToolDone` / `reduceStop` from the ~180-line `TaskContext` SSE effect. No transport, no tool execution, no localStorage inside.
- `TaskContext`'s effect is now thin wiring: `commit(transition)` runs the reducer against live state (read through the functional `setMessages` updater, so no stale snapshot mid-burst) and dispatches side effects (`executeTool`, `setLoading`, task activation) separately. This removes the nested `setState`-within-`setState`.
- Preserved: `has_question` pause (clears spinner, flips to `waiting-for-user`, no terminal `taskStatus`), the pending-task activation gate (`apiTaskId` + `agentRunning` both required — kept as transport bookkeeping in `pendingTaskRef`), `state_version` bookkeeping, tool-call dedup, unknown-tool rejection.

### De-dup INTERACTIVE_TOOLS
The two inline lists were **semantically different**, so they became two named exports in `utils/chat.ts`:
- `INTERACTIVE_TOOLS` (icon/text styling, **includes `scroll`**) — unchanged set, now exported.
- `WAIT_FOR_USER_TOOLS` (show-mode "wait for the user" + element highlight, **no `scroll`**) — the set that was inlined identically in `TaskContext` and `ToolService.requiresHighlight`. Both now consume the shared constant.

## LOC delta
- Existing files: **-203 net** (triple-write removal)
- New reducer module: +272 (relocated + typed + documented)
- Production code total: **+69 net**
- New tests: +271
- Bundle: 561.42 → 561.39 kB (flat, no new deps)

## Tests
+21 reducer unit tests: running, completed/failed/stopped, has_question, tool/call (effect + auto-activate + in-progress line + mode fallback), chat/response, chat/error, ignored events (registered/pong/heartbeat), and the tool lifecycle helpers. **All 204 existing tests stay green (225 total).**

## Verification
- `type-check` (tsc --noEmit): clean
- `lint:check` (eslint --max-warnings 0): clean
- `test:run`: 225 passed (18 files)
- `build` (vite): built, 561.39 kB
- `format:check` (prettier): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)