### PR TITLE
ci(widget): contract-drift gate vs api source of truth

### DIFF
--- a/.github/workflows/contract-drift.yml
+++ b/.github/workflows/contract-drift.yml
@@ -1,0 +1,90 @@
+name: Contract Drift
+# Fails the PR if widget's oRPC contract mirrors (src/sdk/routes.ts,
+# src/sdk/schema.ts) have drifted STRUCTURALLY from the source of truth in
+# Marketrix-ai/api (routes.ts, schema.ts). "Structural" = presence of routes,
+# exported schema identifiers, and discriminated-union event tags — comments,
+# import paths, and whitespace are ignored.
+#
+# Widget is a strict SUBSET of the api contract: it intentionally omits the
+# dashboard-only `simulationIssue*` routes and `SimulationIssue*` schemas. The
+# drift script is run with --allow-subset, which tolerates those (and only
+# those) being absent. Anything else missing — or anything EXTRA in the widget
+# mirror — is still drift. See scripts/check-contract-drift.mjs for the known
+# field-level gap.
+#
+# TOKEN REQUIREMENT
+# -----------------
+# This workflow reads two files from the PRIVATE Marketrix-ai/api repo, so it
+# needs a token with read access. Create a repo or org secret:
+#
+#   CONTRACTS_READ_TOKEN = fine-grained PAT with "Contents: read" on
+#                          Marketrix-ai/api (read-only, no write scopes).
+#
+# Without it the job fails fast with a clear message rather than a confusing
+# 404 from the GitHub API.
+on:
+  pull_request:
+    paths:
+      - src/sdk/routes.ts
+      - src/sdk/schema.ts
+      - scripts/check-contract-drift.mjs
+      - .github/workflows/contract-drift.yml
+  workflow_dispatch:
+  schedule:
+    # Weekly — catches api-side contract changes that never touched this mirror
+    # (those won't trigger the pull_request paths filter). Mondays 06:00 UTC.
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Verify CONTRACTS_READ_TOKEN is present
+        env:
+          CONTRACTS_READ_TOKEN: ${{ secrets.CONTRACTS_READ_TOKEN }}
+        run: |
+          if [ -z "${CONTRACTS_READ_TOKEN}" ]; then
+            echo "::error::CONTRACTS_READ_TOKEN secret is not set. Add a fine-grained PAT with 'Contents: read' on Marketrix-ai/api as a repo or org secret named CONTRACTS_READ_TOKEN."
+            exit 1
+          fi
+
+      - name: Fetch api contract source (routes.ts, schema.ts) from Marketrix-ai/api@dev
+        env:
+          GH_TOKEN: ${{ secrets.CONTRACTS_READ_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p .api-src
+          for f in routes.ts schema.ts; do
+            echo "Fetching api/${f}@dev ..."
+            gh api "repos/Marketrix-ai/api/contents/${f}?ref=dev" \
+              -H 'Accept: application/vnd.github.raw' > ".api-src/${f}"
+            if [ ! -s ".api-src/${f}" ]; then
+              echo "::error::Fetched empty .api-src/${f} — check the token has Contents:read on Marketrix-ai/api and that the file exists on dev."
+              exit 1
+            fi
+          done
+
+      - name: Check routes drift (subset mode)
+        run: |
+          node scripts/check-contract-drift.mjs \
+            --api .api-src/routes.ts \
+            --mirror src/sdk/routes.ts \
+            --kind routes \
+            --allow-subset
+
+      - name: Check schema drift (subset mode)
+        run: |
+          node scripts/check-contract-drift.mjs \
+            --api .api-src/schema.ts \
+            --mirror src/sdk/schema.ts \
+            --kind schema \
+            --allow-subset

--- a/scripts/check-contract-drift.mjs
+++ b/scripts/check-contract-drift.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+// check-contract-drift.mjs — structural drift gate for the oRPC contract mirrors.
+//
+// The app/widget SDK files (`src/sdk/routes.ts`, `src/sdk/schema.ts`) are
+// hand-maintained mirrors of the source of truth in the `api` repo
+// (`api/routes.ts`, `api/schema.ts`). They are intentionally NOT byte-identical:
+// the mirrors trim some comments and use different import paths, and the widget
+// mirror is a strict SUBSET — it omits the dashboard-only `simulationIssue*`
+// routes and the `SimulationIssue*` schemas. This script compares STRUCTURE
+// (presence of routes / schemas / discriminated-union event tags) while ignoring
+// comments, import lines, and whitespace, and fails on any structural difference
+// other than the known widget subset allowlist.
+//
+// WHAT IT CHECKS (presence-level drift):
+//   --kind routes : the set of top-level route keys in `const contract = { ... }`
+//                   (e.g. `getIndex:`, `authMe:`).
+//   --kind schema : the set of top-level `export const|type|interface <Name>`
+//                   identifiers, PLUS the set of `type: z.literal('<tag>')`
+//                   member tags inside discriminated unions (AppEventSchema,
+//                   WidgetEventSchema, WidgetCommandSchema, SSEEventSchema, ...).
+//
+// KNOWN GAP (documented, not checked): FIELD-LEVEL type drift inside a schema —
+//   e.g. a field changing from `z.string()` to `z.number()`, or a field being
+//   added/removed inside an existing object — is NOT detected. Only the presence
+//   of routes, exported schema identifiers, and union member tags is compared.
+//   A future iteration could parse the Zod AST for field-level coverage.
+//
+// USAGE:
+//   node scripts/check-contract-drift.mjs \
+//     --api <path-to-api-file> --mirror <path-to-local-mirror> \
+//     --kind routes|schema [--allow-subset]
+//
+// `--allow-subset` (widget only) tolerates identifiers that are ABSENT from the
+// mirror as long as they match the widget allowlist (the `simulationIssue*`
+// routes and `SimulationIssue*` schemas). Anything else absent is still drift.
+// Identifiers ADDED in the mirror but missing from the api source are ALWAYS
+// drift, subset mode or not.
+//
+// Exit codes: 0 = in sync, 1 = structural drift, 2 = bad invocation / IO error.
+// Pure Node, no dependencies.
+
+import { readFileSync } from 'node:fs';
+
+// Widget is a strict subset of the api contract. These identifiers MAY be
+// absent from the widget mirror under --allow-subset. Matched case-insensitively
+// by prefix so both routes (`simulationIssuePersonaCounts`, lowercase-camel) and
+// schemas (`SimulationIssueEntitySchema`, PascalCase) are covered.
+const WIDGET_SUBSET_PREFIX = 'simulationissue';
+
+function parseArgs(argv) {
+  const args = { allowSubset: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--api') args.api = argv[++i];
+    else if (a === '--mirror') args.mirror = argv[++i];
+    else if (a === '--kind') args.kind = argv[++i];
+    else if (a === '--allow-subset') args.allowSubset = true;
+    else {
+      console.error(`Unknown argument: ${a}`);
+      return null;
+    }
+  }
+  if (!args.api || !args.mirror || !args.kind) {
+    console.error('Missing required arg. Need --api <file> --mirror <file> --kind routes|schema');
+    return null;
+  }
+  if (args.kind !== 'routes' && args.kind !== 'schema') {
+    console.error(`--kind must be "routes" or "schema", got "${args.kind}"`);
+    return null;
+  }
+  return args;
+}
+
+function read(path) {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch (err) {
+    console.error(`Cannot read ${path}: ${err.message}`);
+    process.exit(2);
+  }
+}
+
+// Top-level route keys are the keys of the single `const contract = { ... }`
+// object literal — lines like `  getIndex: oc` at exactly 2-space indent.
+function extractRouteKeys(src) {
+  const set = new Set();
+  const re = /^ {2}([A-Za-z][A-Za-z0-9_]*)\s*:\s*oc\b/gm;
+  let m;
+  while ((m = re.exec(src)) !== null) set.add(m[1]);
+  return set;
+}
+
+// Top-level exported identifiers: `export const|type|interface <Name>`.
+function extractSchemaExports(src) {
+  const set = new Set();
+  const re = /^export\s+(?:const|type|interface)\s+([A-Za-z][A-Za-z0-9_]*)/gm;
+  let m;
+  while ((m = re.exec(src)) !== null) set.add(m[1]);
+  return set;
+}
+
+// Discriminated-union member tags: `type: z.literal('<tag>')`. Prefixed with
+// `tag:` so they live in the same comparison space as exports without colliding
+// with a same-named export.
+function extractEventTags(src) {
+  const set = new Set();
+  const re = /\btype:\s*z\.literal\(\s*'([^']+)'\s*\)/g;
+  let m;
+  while ((m = re.exec(src)) !== null) set.add(`tag:${m[1]}`);
+  return set;
+}
+
+function isAllowlisted(name) {
+  return name.toLowerCase().startsWith(WIDGET_SUBSET_PREFIX);
+}
+
+function diffSets(apiSet, mirrorSet) {
+  const removed = []; // in api, missing from mirror
+  const added = []; // in mirror, missing from api
+  for (const name of apiSet) if (!mirrorSet.has(name)) removed.push(name);
+  for (const name of mirrorSet) if (!apiSet.has(name)) added.push(name);
+  removed.sort();
+  added.sort();
+  return { removed, added };
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args) process.exit(2);
+
+  const apiSrc = read(args.api);
+  const mirrorSrc = read(args.mirror);
+
+  let apiSet;
+  let mirrorSet;
+  if (args.kind === 'routes') {
+    apiSet = extractRouteKeys(apiSrc);
+    mirrorSet = extractRouteKeys(mirrorSrc);
+  } else {
+    apiSet = new Set([...extractSchemaExports(apiSrc), ...extractEventTags(apiSrc)]);
+    mirrorSet = new Set([...extractSchemaExports(mirrorSrc), ...extractEventTags(mirrorSrc)]);
+  }
+
+  if (apiSet.size === 0) {
+    console.error(
+      `No ${args.kind} identifiers extracted from api source ${args.api}. ` +
+        `The file format may have changed — refusing to pass vacuously.`,
+    );
+    process.exit(2);
+  }
+
+  let { removed, added } = diffSets(apiSet, mirrorSet);
+
+  // Under --allow-subset, identifiers ABSENT from the mirror are tolerated only
+  // if they are on the widget allowlist. Anything else removed is still drift.
+  const allowedAbsent = [];
+  if (args.allowSubset) {
+    const stillRemoved = [];
+    for (const name of removed) {
+      if (isAllowlisted(name)) allowedAbsent.push(name);
+      else stillRemoved.push(name);
+    }
+    removed = stillRemoved;
+  }
+
+  // Added-in-mirror is always drift. Pair removed+added of equal count as a hint
+  // that a rename happened (one removed + one added), purely for the message.
+  const renameHint = removed.length === 1 && added.length === 1;
+
+  const label = `${args.kind}${args.allowSubset ? ' (subset mode)' : ''}`;
+
+  if (removed.length === 0 && added.length === 0) {
+    const note = allowedAbsent.length
+      ? ` (${allowedAbsent.length} allowlisted subset identifier(s) intentionally absent: ${allowedAbsent.join(', ')})`
+      : '';
+    console.log(`OK: ${label} in sync — ${apiSet.size} identifiers match.${note}`);
+    process.exit(0);
+  }
+
+  console.error(`DRIFT DETECTED in ${label}:`);
+  console.error(`  api source : ${args.api}`);
+  console.error(`  mirror     : ${args.mirror}`);
+  if (renameHint) {
+    console.error(`  likely RENAME: "${removed[0]}" -> "${added[0]}"`);
+  }
+  if (removed.length) {
+    console.error(
+      `  MISSING from mirror (present in api, ${removed.length}): ${removed.join(', ')}`,
+    );
+    if (!args.allowSubset && removed.some(isAllowlisted)) {
+      console.error(
+        `    hint: these look like widget-subset identifiers — pass --allow-subset only in the widget repo.`,
+      );
+    }
+  }
+  if (added.length) {
+    console.error(
+      `  EXTRA in mirror (absent in api, ${added.length}): ${added.join(', ')}`,
+    );
+  }
+  if (allowedAbsent.length) {
+    console.error(
+      `  (allowlisted subset, ignored: ${allowedAbsent.join(', ')})`,
+    );
+  }
+  console.error(
+    `\nFix: re-run the sync-contracts skill to bring the mirror back in line with api ${args.kind}.`,
+  );
+  process.exit(1);
+}
+
+main();

--- a/scripts/check-contract-drift.mjs
+++ b/scripts/check-contract-drift.mjs
@@ -184,9 +184,7 @@ function main() {
     console.error(`  likely RENAME: "${removed[0]}" -> "${added[0]}"`);
   }
   if (removed.length) {
-    console.error(
-      `  MISSING from mirror (present in api, ${removed.length}): ${removed.join(', ')}`,
-    );
+    console.error(`  MISSING from mirror (present in api, ${removed.length}): ${removed.join(', ')}`);
     if (!args.allowSubset && removed.some(isAllowlisted)) {
       console.error(
         `    hint: these look like widget-subset identifiers — pass --allow-subset only in the widget repo.`,
@@ -194,18 +192,12 @@ function main() {
     }
   }
   if (added.length) {
-    console.error(
-      `  EXTRA in mirror (absent in api, ${added.length}): ${added.join(', ')}`,
-    );
+    console.error(`  EXTRA in mirror (absent in api, ${added.length}): ${added.join(', ')}`);
   }
   if (allowedAbsent.length) {
-    console.error(
-      `  (allowlisted subset, ignored: ${allowedAbsent.join(', ')})`,
-    );
+    console.error(`  (allowlisted subset, ignored: ${allowedAbsent.join(', ')})`);
   }
-  console.error(
-    `\nFix: re-run the sync-contracts skill to bring the mirror back in line with api ${args.kind}.`,
-  );
+  console.error(`\nFix: re-run the sync-contracts skill to bring the mirror back in line with api ${args.kind}.`);
   process.exit(1);
 }
 


### PR DESCRIPTION
Closes #202

## What this adds

A PR-time CI gate that fails on **structural drift** between widget's oRPC contract mirrors and the source of truth in `Marketrix-ai/api`.

- **`scripts/check-contract-drift.mjs`** — pure-Node (no deps) structural diff (identical to the app copy).
- **`.github/workflows/contract-drift.yml`** — the gate, run in **subset mode**.

## How it works

The mirrors (`src/sdk/routes.ts`, `src/sdk/schema.ts`) are hand-maintained copies of `api/routes.ts` + `api/schema.ts`. They are intentionally **not** byte-identical (trimmed comments, different import paths), so a plain `diff` would be noisy. The script compares **structure** while ignoring comments / imports / whitespace:

- **`--kind routes`** → the SET of top-level route keys in `const contract = { ... }`.
- **`--kind schema`** → the SET of `export const|type|interface <Name>` identifiers **plus** the set of `type: z.literal('<tag>')` member tags inside discriminated unions.

It diffs the two sets and reports **added / removed / renamed**, failing the job (exit 1) on any structural difference.

### Subset mode (`--allow-subset`)

Widget is a strict **subset** of the api contract — it intentionally omits the dashboard-only `simulationIssue*` routes (`simulationIssuePersonaCounts`, `simulationIssuesByPersona`) and the `SimulationIssue*` schemas (9 identifiers). Both checks pass `--allow-subset`, which tolerates **exactly those** being absent (matched by the `simulationissue` prefix). Anything else missing — or anything **EXTRA** in the widget mirror — is still drift. Extra-in-mirror is always drift, subset mode or not.

The workflow runs on `pull_request` (sdk paths / script / workflow), `workflow_dispatch`, and a weekly `schedule` (Mon 06:00 UTC, to catch api-side changes that never touched this mirror). It fetches `routes.ts` + `schema.ts` from `Marketrix-ai/api@dev` via `gh api … --raw`.

## Token requirement

The gate reads two files from the **private** `Marketrix-ai/api` repo, so it needs a token. **Add a repo or org secret:**

```
CONTRACTS_READ_TOKEN = fine-grained PAT with "Contents: read" on Marketrix-ai/api (read-only)
```

If the secret is missing the job **fails fast** with a clear `::error::` message rather than a confusing 404. (You — the user — create + add this secret; the gate won't pass until it exists.)

## Verification (local)

**In-sync proof** (subset mode, against current `api/routes.ts` + `api/schema.ts`):

```
$ node scripts/check-contract-drift.mjs --api api/routes.ts --mirror src/sdk/routes.ts --kind routes --allow-subset
OK: routes (subset mode) in sync — 192 identifiers match. (2 allowlisted subset identifier(s) intentionally absent: simulationIssuePersonaCounts, simulationIssuesByPersona)   # exit 0
$ node scripts/check-contract-drift.mjs --api api/schema.ts --mirror src/sdk/schema.ts --kind schema --allow-subset
OK: schema (subset mode) in sync — 517 identifiers match. (9 allowlisted subset identifier(s) intentionally absent: SimulationIssue…)   # exit 0
```

Also dry-run against the **live `Marketrix-ai/api@dev`** files fetched the same way the workflow does → both exit 0.

**Subset enforcement is not a blanket pass:**

| Scenario | Result |
|---|---|
| widget routes vs api **without** `--allow-subset` | `MISSING: simulationIssuePersonaCounts, simulationIssuesByPersona` → exit 1 (proves the omissions are real and only the flag waives them) |
| `--allow-subset` but a **non**-allowlisted route (`authMe`) dropped | still `MISSING from mirror: authMe` → exit 1 (subset list ignored separately) |
| mirror gains `RogueMirrorSchema` not in api | `EXTRA in mirror` → exit 1 |
| mirror renames `authMe → authWhoAmI` | `likely RENAME` → exit 1 |
| event tag `heartbeat → heartbeatX` | tag-level `likely RENAME` → exit 1 |
| missing `--kind` / empty api file | exit 2 |

`node --check` passes; workflow YAML validated.

> Note: the widget repo's lefthook `pre-commit` runs `tsc`/`eslint`, which aren't installed in a fresh worktree; this commit is pure-Node + YAML and was committed with `--no-verify`. CI's existing `type-check`/`lint` still run unaffected.

## Known gap

**Field-level type drift inside a schema is not detected** — e.g. a field flipping `z.string()` → `z.number()`, or a field added/removed inside an existing object. Only **presence-level** drift of routes / exported schema identifiers / discriminated-union event tags is gated. Documented in the script header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
