### PR TITLE
chore(widget): remove "coming soon" Help tab + orphaned News view

### DIFF
--- a/src/components/navigation/MessengerShell.tsx
+++ b/src/components/navigation/MessengerShell.tsx
@@ -13,7 +13,6 @@ import { Icon } from '../base/Icon';
 import { IconButton } from '../base/IconButton';
 import { Stack } from '../base/Stack';
 import { Surface } from '../base/Surface';
-import { Text } from '../base/Text';
 import { HeaderBar } from '../blocks/HeaderBar';
 import { ChatView } from '../views/ChatView';
 import { HomeView } from '../views/HomeView';

--- a/src/components/navigation/MessengerShell.tsx
+++ b/src/components/navigation/MessengerShell.tsx
@@ -1,17 +1,14 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import packageJson from '../../../package.json';
 import { SHADOW } from '../../design-system/shadows';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
 import { useResize } from '../../hooks/useResize';
 import { useWidget } from '../../hooks/useWidget';
 import { createUserMessage } from '../../services/ChatService';
-import { StreamClient } from '../../services/StreamClient';
 import type { ChatMessage, InstructionType, MarketrixConfig, TaskProgress, WidgetView } from '../../types';
 import type { SuggestedActionItem } from '../../utils/suggestedActions';
 import { getPanelPositionStyle } from '../../utils/widgetPositioning';
 import { Badge } from '../base/Badge';
-import { Card } from '../base/Card';
 import { Icon } from '../base/Icon';
 import { IconButton } from '../base/IconButton';
 import { Stack } from '../base/Stack';
@@ -234,52 +231,6 @@ export const MessengerShell: React.FC<MessengerShellProps> = ({
                   onStopScreenShareRef={chatViewStopScreenShareRef}
                   messageInputRef={messageInputRef}
                 />
-              )}
-              {activeView === 'help' && (
-                <Stack id='view-help' role='tabpanel' aria-labelledby='tab-help' height='full' padding='lg'>
-                  <Stack grow align='center' justify='center' gap='sm'>
-                    <Text as='span' variant='faint'>
-                      <Icon name='help' size={32} />
-                    </Text>
-                    <Text size='sm' variant='muted'>
-                      Help – coming soon
-                    </Text>
-                  </Stack>
-                  <Card style={{ margin: '0 12px 12px 12px' }}>
-                    <Text size='xs' variant='faint' style={{ display: 'block' }}>
-                      Widget v{packageJson.version}
-                    </Text>
-                    <Text size='xs' variant='faint' style={{ display: 'block' }}>
-                      API{' '}
-                      {(() => {
-                        try {
-                          return StreamClient.getInstance().isConnected() ? 'connected' : 'disconnected';
-                        } catch {
-                          return '—';
-                        }
-                      })()}
-                    </Text>
-                  </Card>
-                </Stack>
-              )}
-              {activeView === 'news' && (
-                <Stack
-                  id='view-news'
-                  role='tabpanel'
-                  aria-labelledby='tab-news'
-                  height='full'
-                  align='center'
-                  justify='center'
-                  gap='sm'
-                  padding='lg'
-                >
-                  <Text as='span' variant='faint'>
-                    <Icon name='info' size={32} />
-                  </Text>
-                  <Text size='sm' variant='muted'>
-                    News – coming soon
-                  </Text>
-                </Stack>
               )}
             </ViewTransition>
           </Surface>

--- a/src/components/navigation/ShellTabBar.tsx
+++ b/src/components/navigation/ShellTabBar.tsx
@@ -6,7 +6,6 @@ import { TabBar } from '../blocks/TabBar';
 const TAB_DEFS = [
   { id: 'home' as const, icon: 'home' as const, label: 'Home' },
   { id: 'chat' as const, icon: 'chat' as const, label: 'Chat' },
-  { id: 'help' as const, icon: 'help' as const, label: 'Help' },
 ];
 
 export interface ShellTabBarProps {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -99,7 +99,7 @@ export interface TaskProgress {
   timestamp: number;
 }
 
-export type WidgetView = 'home' | 'chat' | 'help' | 'news';
+export type WidgetView = 'home' | 'chat';
 
 export interface WidgetState {
   isOpen: boolean;

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": ".",
     "noEmit": false,
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
Closes #207

## What — clean-slate round 1 (user-verified prototype removals)

- Remove the **Help tab** (`ShellTabBar`) and the **Help** / **News** view panels (`MessengerShell`) — both were "coming soon" placeholders shipping in the embeddable widget customers install.
- Narrow `WidgetView` to `'home' | 'chat'`; drop the now-orphaned `packageJson` / `StreamClient` / `Card` imports that were used only by the Help panel.

−51 lines, no behavior change beyond the removals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)