### PR TITLE
refactor(widget): rename Mindmap → Graph in SDK mirror

### DIFF
--- a/src/sdk/contracts/agent.ts
+++ b/src/sdk/contracts/agent.ts
@@ -1,7 +1,7 @@
 import { oc } from '@orpc/contract';
 import { z } from 'zod';
 
-import { ByAgentIdSchema, MindMapSchema, paginatedListOf, PaginationSchema, SuccessSchema } from './common';
+import { ByAgentIdSchema, GraphSchema, paginatedListOf, PaginationSchema, SuccessSchema } from './common';
 import { AgentEntitySchema, AgentTypeSchema, AgentVoiceSchema } from './entities';
 
 // ---- private helpers ----
@@ -172,16 +172,16 @@ export const agentGet = oc
   .input(ByAgentIdSchema.extend({ include: z.array(z.enum(['knowledge', 'simulations'])).optional() }))
   .output(AgentEntitySchema);
 
-export const agentMindmap = oc
+export const agentGraph = oc
   .route({
     method: 'GET',
     tags: ['Agent'],
-    path: '/agent/{agent_id}/mindmap',
-    summary: 'Get agent mindmap by ID',
-    description: 'Returns the mindmap knowledge graph for the specified agent',
+    path: '/agent/{agent_id}/graph',
+    summary: 'Get agent graph by ID',
+    description: 'Returns the knowledge graph for the specified agent',
   })
   .input(ByAgentIdSchema)
-  .output(MindMapSchema);
+  .output(GraphSchema);
 
 export const agentUpdate = oc
   .route({
@@ -228,7 +228,7 @@ export const agentRoutes = {
   agentCreate,
   agentSearch,
   agentGet,
-  agentMindmap,
+  agentGraph,
   agentUpdate,
   agentDelete,
   agentIndexSimulation,

--- a/src/sdk/contracts/common.ts
+++ b/src/sdk/contracts/common.ts
@@ -79,21 +79,21 @@ export const SlackWebhookUrlSchema = z
   });
 
 /**
- * Mindmap edge schema - transition from one node to another via an action
+ * Graph edge schema - transition from one node to another via an action
  */
-export const MindMapEdgeSchema = z
+export const GraphEdgeSchema = z
   .object({
     start: z.string(),
     end: z.string(),
     action: z.string(),
   })
   .passthrough();
-export type MindMapEdgeData = z.infer<typeof MindMapEdgeSchema>;
+export type GraphEdgeData = z.infer<typeof GraphEdgeSchema>;
 
 /**
- * Mindmap section schema - functional UI section within a page node
+ * Graph section schema - functional UI section within a page node
  */
-export const MindMapSectionSchema = z
+export const GraphSectionSchema = z
   .object({
     id: z.string(),
     label: z.string(),
@@ -106,29 +106,29 @@ export const MindMapSectionSchema = z
   .passthrough();
 
 /**
- * Mindmap node schema - unique page state observed during simulation.
+ * Graph node schema - unique page state observed during simulation.
  * Matches agent's PageNode model (perception/graph.py).
  * Uses passthrough() because the agent model may evolve faster than the schema.
  */
-export const MindMapNodeSchema = z
+export const GraphNodeSchema = z
   .object({
     id: z.string(),
     title: z.string(),
     url: z.string(),
     summary: z.string().default(''),
     screenshot: z.string().default(''),
-    sections: z.array(MindMapSectionSchema).default([]),
+    sections: z.array(GraphSectionSchema).default([]),
     sequence_ids: z.array(z.number()).default([]),
     embedding: z.array(z.number()).nullish(),
   })
   .passthrough();
-export type MindMapNodeData = z.infer<typeof MindMapNodeSchema>;
+export type GraphNodeData = z.infer<typeof GraphNodeSchema>;
 
-export const MindMapSchema = z.object({
-  nodes: z.array(MindMapNodeSchema),
-  edges: z.array(MindMapEdgeSchema),
+export const GraphSchema = z.object({
+  nodes: z.array(GraphNodeSchema),
+  edges: z.array(GraphEdgeSchema),
 });
-export type MindMapData = z.infer<typeof MindMapSchema>;
+export type GraphData = z.infer<typeof GraphSchema>;
 
 /**
  * Skill invocation request — used by SimulationCreateSchema to launch a

--- a/src/sdk/contracts/entities.ts
+++ b/src/sdk/contracts/entities.ts
@@ -48,11 +48,11 @@ export const SimulationStatusSchema = z.enum([
 export type SimulationStatus = z.infer<typeof SimulationStatusSchema>;
 
 /**
- * Mindmap generation lifecycle status on a simulation row. Values written by
- * `mindmapDispatch.ts` and `simulationHooks.ts`; relayed on the
- * `simulation/mindmap-updated` app event.
+ * Graph generation lifecycle status on a simulation row. Values written by
+ * `graphDispatch.ts` and `simulationHooks.ts`; relayed on the
+ * `simulation/graph-updated` app event.
  */
-export const MindmapStatusSchema = z.enum(['pending', 'generating', 'completed', 'failed']);
+export const GraphStatusSchema = z.enum(['pending', 'generating', 'completed', 'failed']);
 
 /**
  * Status carried on the `agent/updated` app event. The event has two emitter
@@ -230,10 +230,10 @@ export const SimulationEntitySchema = BaseEntitySchema.extend({
   source_metadata: z.record(z.string(), z.unknown()).nullish(),
   tasks: z.array(SimulationTaskEntrySchema).optional(),
   agents: z.array(AgentBadgeSchema).optional(),
-  mindmap_status: MindmapStatusSchema.optional(),
-  mindmap_steps_processed: z.number().int().nonnegative().optional(),
-  mindmap_steps_total: z.number().int().nonnegative().optional(),
-  mindmap_error: z.string().nullish(),
+  graph_status: GraphStatusSchema.optional(),
+  graph_steps_processed: z.number().int().nonnegative().optional(),
+  graph_steps_total: z.number().int().nonnegative().optional(),
+  graph_error: z.string().nullish(),
   created_by_user_id: z.number().nullish(),
   // Persona selected for this run in the Generate Simulation modal. Nullable
   // for "Generic" runs and for user-study-flow runs (which use


### PR DESCRIPTION
Closes #209

## What

Widget side of the Mindmap → **Graph** consolidation (pairs with api #625 / agent #635, merged). The widget only carries the **generated SDK mirror** — regenerated canonically from the merged api graph contracts (`sync-consumers widget` → **0 drift**, 8 files match). No hand-written widget code references graph/mindmap.

## Verification
`type-check` clean · `code:check` clean · SDK mirror **0 drift** vs api@dev · zero `mindmap` in src.

🤖 Generated with [Claude Code](https://claude.com/claude-code)