### PR TITLE
refactor(widget): lingo v3.8.33 — service class names + SDK regen

### DIFF
--- a/src/context/ChatContext.tsx
+++ b/src/context/ChatContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
 
-import { MarketrixApiService } from '../services/ApiService';
+import { ApiService } from '../services/ApiService';
 import { createAgentMessage, createUserMessage } from '../services/ChatService';
 import { configManager } from '../services/ConfigManager';
 import { StreamClient } from '../services/StreamClient';
@@ -140,7 +140,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
       addMessage(placeholderMsg);
       uiActions.setLoading(true);
 
-      const apiService = new MarketrixApiService(config);
+      const apiService = new ApiService(config);
       try {
         if (applicationId) {
           apiService.updateConfig({ mtxApp: applicationId });

--- a/src/context/TaskContext.tsx
+++ b/src/context/TaskContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useCallback, useContext, useEffect, useMemo, useR
 
 import type { WidgetEvent } from '../sdk';
 import { StreamClient, type StreamStatus } from '../services/StreamClient';
-import { toolExecutionService } from '../services/ToolService';
+import { toolService } from '../services/ToolService';
 import type { ChatMessage, InstructionType, TaskProgress } from '../types';
 import { BROWSER_TOOLS } from '../types/browserTools';
 import type { ChatState } from './ChatContext';
@@ -159,7 +159,7 @@ export const TaskProvider: React.FC<TaskProviderProps> = ({
 
     const executeToolCall = async (effect: Extract<SseEffect, { type: 'executeTool' }>) => {
       const { callId, tool, args, mode, explanation } = effect;
-      const result = await toolExecutionService.executeTool(tool, args, mode, explanation);
+      const result = await toolService.executeTool(tool, args, mode, explanation);
 
       if (result.success) {
         try {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,7 +14,7 @@ import { createConfigFromSettings } from './services/ConfigManager';
 import { SessionRecorder } from './services/SessionRecorder';
 import { storageService } from './services/StorageService';
 import { StreamClient } from './services/StreamClient';
-import { WidgetValidationService } from './services/ValidationService';
+import { ValidationService } from './services/ValidationService';
 import { WidgetService } from './services/WidgetService';
 import type { AddWidgetConfig, MarketrixConfig, MarketrixWidgetProps } from './types';
 import {
@@ -147,7 +147,7 @@ async function initWidgetInternal(config: MarketrixConfig, container?: HTMLEleme
   }
 
   showWidgetSettingsLoader('Validating widget configuration...');
-  const validationService = new WidgetValidationService();
+  const validationService = new ValidationService();
   const validationResult = await validationService.validateConfig(config);
 
   if (!validationResult.isValid) {

--- a/src/sdk/contracts/agent.ts
+++ b/src/sdk/contracts/agent.ts
@@ -32,7 +32,7 @@ export const AgentCreateSchema = AgentEntitySchema.partial().extend({
   knowledge_ids: KnowledgeIdsSchema,
   simulation_ids: SimulationIdsSchema,
 });
-export type AgentCreationData = z.infer<typeof AgentCreateSchema>;
+export type AgentCreateData = z.infer<typeof AgentCreateSchema>;
 
 export const AgentUpdateSchema = AgentEntitySchema.partial().extend({
   file: z.instanceof(File).optional(),
@@ -49,7 +49,7 @@ export const AgentTaskStartResponseSchema = z.object({
   text: z.string(),
   task_id: z.string().optional(),
 });
-export type AgentTaskStartResponseData = z.infer<typeof AgentTaskStartResponseSchema>;
+export type AgentTaskStartResponse = z.infer<typeof AgentTaskStartResponseSchema>;
 
 /**
  * Agent task stop response schema
@@ -59,7 +59,7 @@ export const AgentTaskStopResponseSchema = z.object({
   status: z.string(),
   message: z.string().optional(),
 });
-export type AgentTaskStopResponseData = z.infer<typeof AgentTaskStopResponseSchema>;
+export type AgentTaskStopResponse = z.infer<typeof AgentTaskStopResponseSchema>;
 
 /**
  * Agent task status response schema
@@ -72,17 +72,17 @@ export const AgentTaskStatusResponseSchema = z.object({
   error: z.string().optional(),
   message: z.string().optional(),
 });
-export type AgentTaskStatusResponseData = z.infer<typeof AgentTaskStatusResponseSchema>;
+export type AgentTaskStatusResponse = z.infer<typeof AgentTaskStatusResponseSchema>;
 
 export const AgentSearchConfigSchema = z.object({
-  contentType: z.enum(['document', 'video', 'automation_log', 'screenshot', 'all']).optional(),
+  content_type: z.enum(['document', 'video', 'automation_log', 'screenshot', 'all']).optional(),
   context: z.string().optional(),
-  previousActions: z.array(z.string()).optional(),
+  previous_actions: z.array(z.string()).optional(),
   top: z.coerce.number().min(1).max(100).optional(),
-  minConfidence: z.coerce.number().min(0).max(1).optional(),
+  min_confidence: z.coerce.number().min(0).max(1).optional(),
   entities: z.array(z.string()).optional(),
-  useVectorSearch: z.boolean().optional(),
-  vectorThreshold: z.coerce.number().min(0).max(1).optional(),
+  use_vector_search: z.boolean().optional(),
+  vector_threshold: z.coerce.number().min(0).max(1).optional(),
 });
 export type AgentSearchConfig = z.infer<typeof AgentSearchConfigSchema>;
 

--- a/src/sdk/contracts/entities.ts
+++ b/src/sdk/contracts/entities.ts
@@ -58,21 +58,21 @@ export const GraphStatusSchema = z.enum(['pending', 'generating', 'completed', '
  * Status carried on the `agent/updated` app event. The event has two emitter
  * lineages: (1) `agentService` + `agentLearningHooks` emit an agent-entity
  * status (`AgentStatusSchema`), and (2) the agentTask flow's `eventMapping`
- * emits a task-status (`SimulationTaskStatusSchema`). The union captures both
- * vocabularies so downstream consumers get exhaustiveness rather than `string`.
+ * emits a task-status. A `type` discriminant disambiguates the two vocabularies
+ * so consumers don't have to guess which status set a value belongs to.
  */
-export const AgentUpdatedStatusSchema = z.enum([
-  // Agent entity statuses (AgentStatusSchema)
-  'active',
-  'learning',
-  'error',
-  // Task-level statuses surfaced via agentTask flow transitions
+export const AgentUpdatedTaskStatusSchema = z.enum([
   'queued',
   'running',
   'completed',
   'failed',
   'has_question',
   'stopped',
+]);
+
+export const AgentUpdatedStatusSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('agent'), status: AgentStatusSchema }),
+  z.object({ type: z.literal('task'), status: AgentUpdatedTaskStatusSchema }),
 ]);
 
 export const ApplicationTypeSchema = z.enum(['app', 'website']);
@@ -168,7 +168,7 @@ export type KnowledgeData = z.infer<typeof KnowledgeEntitySchema>;
 export const QAVerdictSchema = z.enum(['passed', 'needs_healing', 'failed']);
 export type QAVerdict = z.infer<typeof QAVerdictSchema>;
 
-// ── QA Uxr Response (completion payload for process/refine streams) ──
+// ── QA Process Response (completion payload for process/refine streams) ──
 export const QAProcessResponseSchema = z.object({
   ultimate_goal: z.string(),
   test_cases: z.array(
@@ -356,8 +356,8 @@ export type StateTriggerData = z.infer<typeof StateTriggerEntitySchema>;
  * Canonical wire vocabulary; `deriveQARunStats` returns `'running'` directly.
  * `'pending'` is the empty-task initial state.
  */
-export const QARunDerivedStatusSchema = z.enum(['pending', 'running', 'completed', 'failed', 'stopped']);
-export type QARunDerivedStatus = z.infer<typeof QARunDerivedStatusSchema>;
+export const QARunStatusSchema = z.enum(['pending', 'running', 'completed', 'failed', 'stopped']);
+export type QARunStatus = z.infer<typeof QARunStatusSchema>;
 
 // ── Activity Log ──
 

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -3,7 +3,7 @@ import type { MarketrixConfig, SendMessageRequest, SendMessageResponse } from '.
 import { sessionManager } from './SessionManager';
 import { StreamClient } from './StreamClient';
 
-export class MarketrixApiService {
+export class ApiService {
   private config: MarketrixConfig;
 
   constructor(config: MarketrixConfig) {
@@ -147,4 +147,4 @@ export class MarketrixApiService {
   }
 }
 
-export default MarketrixApiService;
+export default ApiService;

--- a/src/services/DomService.ts
+++ b/src/services/DomService.ts
@@ -39,8 +39,8 @@ export interface ValidatedElementResult extends ElementLookupResult {
   validation: ValidationResult;
 }
 
-export class DOMService {
-  private static instance: DOMService;
+export class DomService {
+  private static instance: DomService;
   private elementMap: Map<number, Element> = new Map();
   private elementToSequence: WeakMap<Element, number> = new WeakMap();
   private selectorMap: Map<number, string> = new Map();
@@ -54,11 +54,11 @@ export class DOMService {
     // No longer restoring state internally
   }
 
-  static getInstance(): DOMService {
-    if (!DOMService.instance) {
-      DOMService.instance = new DOMService();
+  static getInstance(): DomService {
+    if (!DomService.instance) {
+      DomService.instance = new DomService();
     }
-    return DOMService.instance;
+    return DomService.instance;
   }
 
   /**
@@ -228,11 +228,11 @@ export class DOMService {
       if (this.selectorMap.size > 0 || this.fingerprintMap.size > 0) {
         this.isIndexed = true;
         console.log(
-          `[DOMService] Restored ${this.selectorMap.size} selectors and ${this.fingerprintMap.size} fingerprints`,
+          `[DomService] Restored ${this.selectorMap.size} selectors and ${this.fingerprintMap.size} fingerprints`,
         );
       }
     } catch (e) {
-      console.warn('[DOMService] Failed to import state:', e);
+      console.warn('[DomService] Failed to import state:', e);
     }
   }
 
@@ -242,7 +242,7 @@ export class DOMService {
    */
   indexInteractableElements(): Array<[number, Element]> {
     if (this.indexingInProgress) {
-      console.warn('[DOMService] Indexing already in progress, skipping concurrent call');
+      console.warn('[DomService] Indexing already in progress, skipping concurrent call');
       return [];
     }
 
@@ -319,7 +319,7 @@ export class DOMService {
       this.isIndexed = true;
       this.indexVersion++;
 
-      console.log(`[DOMService] Indexed ${sequenceNumber} elements (version ${this.indexVersion})`);
+      console.log(`[DomService] Indexed ${sequenceNumber} elements (version ${this.indexVersion})`);
 
       return indexedElements;
     } finally {
@@ -523,7 +523,7 @@ export class DOMService {
             }
           } catch (e) {
             // Selector might be invalid, skip this element
-            console.warn(`[DOMService] Failed to apply data attributes for index ${index}:`, e);
+            console.warn(`[DomService] Failed to apply data attributes for index ${index}:`, e);
           }
         }
       }
@@ -673,7 +673,7 @@ export class DOMService {
             element = queriedElement;
           }
         } catch (e) {
-          console.warn(`[DOMService] Failed to find element by selector for index ${index}:`, e);
+          console.warn(`[DomService] Failed to find element by selector for index ${index}:`, e);
         }
       }
     }
@@ -749,4 +749,4 @@ export class DOMService {
   }
 }
 
-export const domService = DOMService.getInstance();
+export const domService = DomService.getInstance();

--- a/src/services/ToolService.ts
+++ b/src/services/ToolService.ts
@@ -105,16 +105,16 @@ export interface ExtractParams {
   start_from_char?: number;
 }
 
-export class ToolExecutionService {
-  private static instance: ToolExecutionService;
+export class ToolService {
+  private static instance: ToolService;
 
   private constructor() {}
 
-  static getInstance(): ToolExecutionService {
-    if (!ToolExecutionService.instance) {
-      ToolExecutionService.instance = new ToolExecutionService();
+  static getInstance(): ToolService {
+    if (!ToolService.instance) {
+      ToolService.instance = new ToolService();
     }
-    return ToolExecutionService.instance;
+    return ToolService.instance;
   }
 
   async executeTool(
@@ -124,7 +124,7 @@ export class ToolExecutionService {
     explanation: string = '',
   ): Promise<ToolExecutionResult<unknown>> {
     try {
-      console.log(`[ToolExecutionService] Executing ${toolName} (mode: ${mode})`);
+      console.log(`[ToolService] Executing ${toolName} (mode: ${mode})`);
 
       if (mode === 'show' && this.requiresHighlight(toolName)) {
         const index = args.index as number | undefined;
@@ -254,11 +254,11 @@ export class ToolExecutionService {
       try {
         element.click();
       } catch (e) {
-        console.warn('[ToolExecutionService] Click error:', e);
+        console.warn('[ToolService] Click error:', e);
         try {
           element.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
         } catch (fallbackError) {
-          console.warn('[ToolExecutionService] Fallback click failed:', fallbackError);
+          console.warn('[ToolService] Fallback click failed:', fallbackError);
         }
       }
     }, 50);
@@ -881,4 +881,4 @@ export class ToolExecutionService {
   }
 }
 
-export const toolExecutionService = ToolExecutionService.getInstance();
+export const toolService = ToolService.getInstance();

--- a/src/services/ValidationService.ts
+++ b/src/services/ValidationService.ts
@@ -11,13 +11,13 @@ export interface WidgetValidationResult {
 }
 
 /**
- * WidgetValidationService
+ * ValidationService
  *
  * Validates widget configuration by checking:
  * 1. Widget exists (via marketrix_id and marketrix_key) OR
  * 2. Agent ID and Application ID exist and match
  */
-export class WidgetValidationService {
+export class ValidationService {
   private config?: MarketrixConfig;
 
   /**
@@ -211,4 +211,4 @@ export class WidgetValidationService {
   }
 }
 
-export default WidgetValidationService;
+export default ValidationService;


### PR DESCRIPTION
Closes #213

Widget half of the v3.8.33 workspace-wide lingo shrink + deep audit.

- **Service class names now match their files**: `DOMService→DomService`, `ToolExecutionService→ToolService` (+ `toolExecutionService` singleton → `toolService`), `WidgetValidationService→ValidationService`, `MarketrixApiService→ApiService`.
- **Regenerated SDK mirror** to pick up the api contract renames (`Agent*ResponseData→*Response`, `AgentCreationData→AgentCreateData`, `AgentSearchConfig` snake_case, `AgentUpdatedStatus` discriminated union, `QARunDerivedStatus→QARunStatus`). No widget app code referenced the renamed symbols.

Green: type-check + lint + build (lefthook check+lint green).