### PR TITLE
feat: proto clean-slate + graph_id rename (v3.8.35)

### DIFF
--- a/src/sdk/contracts/activityLog.ts
+++ b/src/sdk/contracts/activityLog.ts
@@ -4,8 +4,6 @@ import { z } from 'zod';
 import { paginatedListOf, PaginationSchema } from './common';
 import { ActionLogCreateSchema, ActionLogEntitySchema, ActionLogTypeSchema } from './entities';
 
-// ---- procedures ----
-
 export const activityLogCreate = oc
   .route({
     method: 'POST',
@@ -35,8 +33,6 @@ export const activityLogSearch = oc
       .extend(PaginationSchema.shape),
   )
   .output(paginatedListOf(ActionLogEntitySchema));
-
-// ---- domain aggregate ----
 
 export const activityLogRoutes = {
   activityLogCreate,

--- a/src/sdk/contracts/agent.ts
+++ b/src/sdk/contracts/agent.ts
@@ -4,8 +4,6 @@ import { z } from 'zod';
 import { ByAgentIdSchema, GraphSchema, paginatedListOf, PaginationSchema, SuccessSchema } from './common';
 import { AgentEntitySchema, AgentTypeSchema, AgentVoiceSchema } from './entities';
 
-// ---- private helpers ----
-
 const parseIds = (val: unknown): number[] => {
   if (Array.isArray(val)) return val.map(v => Number(v));
   if (typeof val === 'string') {
@@ -17,8 +15,6 @@ const parseIds = (val: unknown): number[] => {
 
 const KnowledgeIdsSchema = z.union([z.array(z.number()), z.string()]).transform(parseIds);
 const SimulationIdsSchema = z.union([z.array(z.number()), z.string()]).transform(parseIds);
-
-// ---- agent-only schemas ----
 
 export const AgentCreateSchema = AgentEntitySchema.partial().extend({
   application_id: z.coerce.number(),
@@ -41,30 +37,18 @@ export const AgentUpdateSchema = AgentEntitySchema.partial().extend({
 });
 export type AgentUpdateData = z.infer<typeof AgentUpdateSchema>;
 
-/**
- * Agent task start response schema
- * Response from agent server when starting a task
- */
 export const AgentTaskStartResponseSchema = z.object({
   text: z.string(),
   task_id: z.string().optional(),
 });
 export type AgentTaskStartResponse = z.infer<typeof AgentTaskStartResponseSchema>;
 
-/**
- * Agent task stop response schema
- * Response from agent server when stopping a task
- */
 export const AgentTaskStopResponseSchema = z.object({
   status: z.string(),
   message: z.string().optional(),
 });
 export type AgentTaskStopResponse = z.infer<typeof AgentTaskStopResponseSchema>;
 
-/**
- * Agent task status response schema
- * Response from agent server for task status queries
- */
 export const AgentTaskStatusResponseSchema = z.object({
   task_id: z.string().optional(),
   status: z.string().optional(),
@@ -126,8 +110,6 @@ export const AgentSimulationIndexResponseSchema = z.object({
   message: z.string(),
 });
 export type AgentSimulationIndexResponse = z.infer<typeof AgentSimulationIndexResponseSchema>;
-
-// ---- procedures ----
 
 export const agentCreate = oc
   .route({
@@ -221,8 +203,6 @@ export const agentIndexSimulation = oc
   })
   .input(AgentSimulationIndexRequestSchema.extend({ agent_id: z.coerce.number() }))
   .output(AgentSimulationIndexResponseSchema);
-
-// ---- domain aggregate ----
 
 export const agentRoutes = {
   agentCreate,

--- a/src/sdk/contracts/application.ts
+++ b/src/sdk/contracts/application.ts
@@ -4,8 +4,6 @@ import { z } from 'zod';
 import { ByApplicationIdSchema, paginatedListOf, PaginationSchema, SuccessSchema } from './common';
 import { ApplicationEntitySchema, ApplicationReadSchema, ApplicationTypeSchema, WidgetEntitySchema } from './entities';
 
-// ---- application-only schemas ----
-
 export const ApplicationFilterSchema = z.object({
   application_id: z.coerce.number().optional(),
 });
@@ -20,8 +18,6 @@ export type ApplicationCreateData = z.infer<typeof ApplicationCreateSchema>;
 
 export const ApplicationUpdateSchema = ApplicationEntitySchema.partial().omit({ workspace_id: true, slug: true });
 export type ApplicationUpdateData = z.infer<typeof ApplicationUpdateSchema>;
-
-// ---- procedures ----
 
 export const applicationCreate = oc
   .route({
@@ -95,8 +91,6 @@ export const applicationDelete = oc
   })
   .input(ByApplicationIdSchema)
   .output(SuccessSchema);
-
-// ---- domain aggregate ----
 
 export const applicationRoutes = {
   applicationCreate,

--- a/src/sdk/contracts/chat.ts
+++ b/src/sdk/contracts/chat.ts
@@ -1,8 +1,6 @@
 import { oc } from '@orpc/contract';
 import { z } from 'zod';
 
-// ---- procedures ----
-
 export const chatCreate = oc
   .route({
     method: 'POST',
@@ -12,8 +10,6 @@ export const chatCreate = oc
     description: 'Initializes new chat thread and returns session ID',
   })
   .output(z.string());
-
-// ---- domain aggregate ----
 
 export const chatRoutes = {
   chatCreate,

--- a/src/sdk/contracts/common.ts
+++ b/src/sdk/contracts/common.ts
@@ -11,7 +11,6 @@ export const BaseEntitySchema = z.object({
   updated_at: z.coerce.date().optional(),
 });
 
-// ── Shared input helpers ──
 export const ByIdSchema = z.object({ id: z.coerce.number() });
 export const BySlugSchema = z.object({ slug: z.string() });
 export const ByAgentIdSchema = z.object({ agent_id: z.coerce.number() });
@@ -24,8 +23,6 @@ export const PaginationSchema = z.object({
   limit: z.coerce.number().optional().default(50),
   offset: z.coerce.number().optional().default(0),
 });
-
-// ── List wrappers ──
 
 /** Paginated list for unbounded queries — includes total/limit/offset for pagination */
 export const paginatedListOf = <T extends z.ZodTypeAny>(schema: T) =>

--- a/src/sdk/contracts/entities.ts
+++ b/src/sdk/contracts/entities.ts
@@ -145,9 +145,6 @@ export const AgentBadgeSchema = z.object({
 });
 export type AgentBadgeData = z.infer<typeof AgentBadgeSchema>;
 
-/**
- * Knowledge base document schema
- */
 export const KnowledgeEntitySchema = BaseEntitySchema.extend({
   workspace_id: z.number(),
   application_id: z.number().optional(),
@@ -168,7 +165,6 @@ export type KnowledgeData = z.infer<typeof KnowledgeEntitySchema>;
 export const QAVerdictSchema = z.enum(['passed', 'needs_healing', 'failed']);
 export type QAVerdict = z.infer<typeof QAVerdictSchema>;
 
-// ── QA Process Response (completion payload for process/refine streams) ──
 export const QAProcessResponseSchema = z.object({
   ultimate_goal: z.string(),
   test_cases: z.array(
@@ -226,7 +222,7 @@ export const SimulationEntitySchema = BaseEntitySchema.extend({
   pinned: z.boolean().optional(),
   source: z.enum(['direct', 'qa']).optional(),
   agent_name: z.string().nullish(),
-  graph_index_id: z.string().nullish(),
+  graph_id: z.string().nullish(),
   source_metadata: z.record(z.string(), z.unknown()).nullish(),
   tasks: z.array(SimulationTaskEntrySchema).optional(),
   agents: z.array(AgentBadgeSchema).optional(),
@@ -256,7 +252,7 @@ export const AgentEntitySchema = BaseEntitySchema.extend({
   agent_description: z.string().nullish(),
   instructions: z.string().nullish(),
   image_url: z.string().nullish(),
-  graph_index_id: z.string().nullish(),
+  graph_id: z.string().nullish(),
   status: AgentStatusSchema,
   status_message: z.string().nullish(),
   learning_progress: LearningProgressSchema.nullish(),
@@ -359,8 +355,6 @@ export type StateTriggerData = z.infer<typeof StateTriggerEntitySchema>;
 export const QARunStatusSchema = z.enum(['pending', 'running', 'completed', 'failed', 'stopped']);
 export type QARunStatus = z.infer<typeof QARunStatusSchema>;
 
-// ── Activity Log ──
-
 export const ActionLogTypeSchema = z.enum([
   'user_login',
   'url_visit',
@@ -394,10 +388,6 @@ export const ActionLogTypeSchema = z.enum([
 ]);
 export type ActionLogType = z.infer<typeof ActionLogTypeSchema>;
 
-/**
- * Action log metadata schema
- * Captures common metadata fields used across different action log types
- */
 export const ActionLogMetadataSchema = z
   .object({
     details: z.string().optional(),
@@ -431,8 +421,6 @@ export type ActionLogData = z.infer<typeof ActionLogEntitySchema>;
 export const ActionLogCreateSchema = ActionLogEntitySchema.partial().extend({
   type: ActionLogTypeSchema,
 });
-
-// ── User Quota ──
 
 export const UserQuotaSchema = z.object({
   user_id: z.number(),

--- a/src/sdk/contracts/widget.ts
+++ b/src/sdk/contracts/widget.ts
@@ -12,8 +12,6 @@ import {
   WorkspaceEntitySchema,
 } from './entities';
 
-// ---- widget-only schemas ----
-
 export const WidgetInfoSchema = WidgetEntitySchema.extend({
   application: ApplicationReadSchema.partial(),
   workspace: WorkspaceEntitySchema.partial(),
@@ -126,8 +124,6 @@ export const WidgetCommandSchema = z.discriminatedUnion('type', [
 ]);
 export type WidgetCommand = z.infer<typeof WidgetCommandSchema>;
 
-// ---- procedures ----
-
 export const widgetCreate = oc
   .route({
     method: 'POST',
@@ -229,8 +225,6 @@ export const widgetMessage = oc
     }),
   )
   .output(z.object({ ok: z.boolean() }));
-
-// ---- domain aggregate ----
 
 export const widgetRoutes = {
   widgetCreate,


### PR DESCRIPTION
Closes #217

Regen SDK mirror only (graph_id + comment-debloat catch-up); no widget code change. Gates: tsc + eslint + build clean.