### PR TITLE
[Bug Fix] - Prevent redundant stream connection attempts during pending or registered states

### DIFF
--- a/src/services/StreamClient.ts
+++ b/src/services/StreamClient.ts
@@ -54,7 +54,10 @@ export class StreamClient {
       this.isIntentionallyDisconnected = false;
     }
 
-    if (this.isConnected() && this.chatId === chatId) {
+    if (
+      this.chatId === chatId &&
+      (this.status === 'connecting' || this.status === 'connected' || this.status === 'registered')
+    ) {
       return;
     }
 


### PR DESCRIPTION
## Summary
Optimizes the stream initialization guard in `StreamClient` to prevent duplicate connection or registration processes. 

Previously, the client only short-circuited if it was fully connected (`isConnected()`). If a connection was already in progress (`connecting`) or already authorized (`registered`) for the same `chatId`, rapid subsequent calls could trigger redundant connection workflows. The guard now checks for any active or transitioning status (`connecting`, `connected`, or `registered`) for the matching `chatId` before proceeding.

## Related issue
<!-- Use Closes/Fixes/Resolves to link. project-sync moves the linked issue to In Progress. -->
<!-- Closes # -->

## Test plan
- [ ] Verify that triggering multiple connection requests in rapid succession for the same `chatId` does not initiate duplicate connection attempts.
- [ ] Confirm that transitionary states (`connecting` -> `connected` -> `registered`) flow correctly without being blocked.

## Checklist
- [ ] CI passes (type-check + lint)
- [ ] Shared contracts in sync if changed (`routes.ts`, `schema.ts`, `proto`)