### PR TITLE
chore(widget): re-sync SDK mirror after api contract cleanup

### DIFF
--- a/src/sdk/contracts/common.ts
+++ b/src/sdk/contracts/common.ts
@@ -39,15 +39,6 @@ export const listOf = <T extends z.ZodTypeAny>(schema: T) =>
     count: z.number(),
   });
 
-/** Value types in QA test case version diffs */
-export const DiffValueSchema = z.union([z.string(), z.number(), z.boolean(), z.array(z.string()), z.null()]);
-
-export const ContextRefSchema = z.object({
-  type: z.enum(['doc', 'sim', 'session']),
-  id: z.string(),
-  label: z.string(),
-});
-
 export const SuccessSchema = z.object({ success: z.literal(true) });
 export const SuccessWithMessageSchema = SuccessSchema.extend({ message: z.string() });
 

--- a/src/sdk/contracts/entities.ts
+++ b/src/sdk/contracts/entities.ts
@@ -116,26 +116,6 @@ export const VIEWPORT_DIMENSIONS: Record<ViewportName, { width: number; height: 
   mobile: { width: 393, height: 852 },
 };
 
-export const QAProcessResponseSchema = z.object({
-  ultimate_goal: z.string(),
-  test_cases: z.array(
-    z.object({
-      test_title: z.string(),
-      test_objective: z.string(),
-      test_steps: z.array(z.string()),
-      expected_outcome: z.string(),
-      priority: z.enum(['Low', 'Medium', 'High']),
-    }),
-  ),
-  summary: z.object({
-    total_tests: z.number(),
-    high_priority: z.number(),
-    medium_priority: z.number(),
-    low_priority: z.number(),
-    estimated_time_minutes: z.number(),
-  }),
-});
-
 export const TaskDependencySchema = z.object({
   task_id: z.string(),
   condition: z.enum(['pass']).optional(),
@@ -173,8 +153,6 @@ export const StepReactionSchema = z.object({
   reaction: z.string(),
   sentiment: SentimentSchema.nullable(),
 });
-export const JourneyReactionSchema = z.object({ reaction: z.string(), sentiment: SentimentSchema });
-
 // One reactor's reaction to one simulation. run_id/user_index are null for a
 // direct sim's attached persona; set for a study persona-user. Shared by the
 // direct-sim read path AND the study replay.


### PR DESCRIPTION
Regenerated `src/sdk/` to match the cleaned api contract (PR Marketrix-ai/api#744) — removes dead/retired closure schemas (QAProcessResponse, DiffValue, ContextRef, etc.). Generated mirror only; widget runtime code referenced none of them. Keeps the `drift` check green now that api dev dropped those schemas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015JWfa9GJvwJAQAmEFthrYj