### PR TITLE
test(widget): drop dead self-asserting status literals

### DIFF
--- a/src/sdk/contracts/entities.ts
+++ b/src/sdk/contracts/entities.ts
@@ -124,7 +124,7 @@ export type TaskDependency = z.infer<typeof TaskDependencySchema>;
 
 /**
  * A single task within a simulation. Direct simulations have 1 task (the prompt).
- * QA simulations have N tasks (one per test case).
+ * QA simulations have N tasks (one per journey).
  */
 export const SimulationTaskEntrySchema = z.object({
   task_id: z.string(),

--- a/src/services/__tests__/widget-status-mapping.test.ts
+++ b/src/services/__tests__/widget-status-mapping.test.ts
@@ -1,77 +1,44 @@
 /**
- * Widget task status contract — aligns with SimulationTaskStatus / QATaskStatus.
+ * Widget task-status contract — the event-surface vocabulary carried by WidgetEventSchema.
  * Widget `task/status` union: `'running' | 'completed' | 'failed' | 'stopped' | 'has_question'`.
  */
 import { describe, expect, it } from 'vitest';
 
 import { WidgetEventSchema } from '@/sdk';
 
-describe('Widget task status contract — Wave 14 (C1 cutover)', () => {
-  const SIM_TASK_STATUSES = ['queued', 'running', 'completed', 'failed', 'has_question', 'stopped'] as const;
-
-  const QA_TASK_STATUSES = ['queued', 'running', 'passed', 'failed', 'needs_healing', 'stopped'] as const;
-
-  // Canonical post-Wave-14 set carried by WidgetEventSchema.task/status.
+describe('widget event surface (WidgetEventSchema.task/status)', () => {
   const WIDGET_TASK_STATUSES = ['running', 'completed', 'failed', 'stopped', 'has_question'] as const;
 
-  it('sim task statuses include all 6 expected values', () => {
-    expect(SIM_TASK_STATUSES.length).toBe(6);
-    expect(SIM_TASK_STATUSES).toContain('running');
-    expect(SIM_TASK_STATUSES).toContain('has_question');
+  it('union has exactly 5 values', () => {
+    expect(WIDGET_TASK_STATUSES.length).toBe(5);
   });
 
-  it('QA task statuses include all 6 expected values', () => {
-    expect(QA_TASK_STATUSES.length).toBe(6);
-    expect(QA_TASK_STATUSES).toContain('passed');
-    expect(QA_TASK_STATUSES).toContain('needs_healing');
+  it('"running" replaces legacy "started"', () => {
+    expect(WIDGET_TASK_STATUSES).toContain('running');
+    expect(WIDGET_TASK_STATUSES as readonly string[]).not.toContain('started');
   });
 
-  it('sim task uses "running" not "started" (Wave 8a rename)', () => {
-    expect(SIM_TASK_STATUSES).toContain('running');
-    expect(SIM_TASK_STATUSES as readonly string[]).not.toContain('started');
+  it('"in_progress" is no longer a valid widget task status', () => {
+    expect(WIDGET_TASK_STATUSES as readonly string[]).not.toContain('in_progress');
   });
 
-  it('QA task does not have "completed" (uses passed/failed instead)', () => {
-    expect(QA_TASK_STATUSES as readonly string[]).not.toContain('completed');
+  it.each(WIDGET_TASK_STATUSES)('schema accepts "%s" as a valid task/status', status => {
+    const result = WidgetEventSchema.safeParse({ type: 'task/status', status });
+    expect(
+      result.success,
+      `expected status="${status}" to be accepted; errors: ${
+        !result.success ? JSON.stringify(result.error.issues) : 'none'
+      }`,
+    ).toBe(true);
   });
 
-  it('QA task does not have "has_question" (sim-only)', () => {
-    expect(QA_TASK_STATUSES as readonly string[]).not.toContain('has_question');
+  it('schema REJECTS legacy "started"', () => {
+    const result = WidgetEventSchema.safeParse({ type: 'task/status', status: 'started' });
+    expect(result.success).toBe(false);
   });
 
-  // Wave 14 (C1): widget event-surface vocabulary alignment.
-  describe('widget event surface (WidgetEventSchema.task/status)', () => {
-    it('post-Wave-14 union has exactly 5 values', () => {
-      expect(WIDGET_TASK_STATUSES.length).toBe(5);
-    });
-
-    it('"running" replaces legacy "started"', () => {
-      expect(WIDGET_TASK_STATUSES).toContain('running');
-      expect(WIDGET_TASK_STATUSES as readonly string[]).not.toContain('started');
-    });
-
-    it('"in_progress" is no longer a valid widget task status', () => {
-      expect(WIDGET_TASK_STATUSES as readonly string[]).not.toContain('in_progress');
-    });
-
-    it.each(WIDGET_TASK_STATUSES)('schema accepts "%s" as a valid task/status', status => {
-      const result = WidgetEventSchema.safeParse({ type: 'task/status', status });
-      expect(
-        result.success,
-        `expected status="${status}" to be accepted; errors: ${
-          !result.success ? JSON.stringify(result.error.issues) : 'none'
-        }`,
-      ).toBe(true);
-    });
-
-    it('schema REJECTS legacy "started" (Wave 14 contract change)', () => {
-      const result = WidgetEventSchema.safeParse({ type: 'task/status', status: 'started' });
-      expect(result.success).toBe(false);
-    });
-
-    it('schema REJECTS legacy "in_progress" (Wave 14 contract change)', () => {
-      const result = WidgetEventSchema.safeParse({ type: 'task/status', status: 'in_progress' });
-      expect(result.success).toBe(false);
-    });
+  it('schema REJECTS legacy "in_progress"', () => {
+    const result = WidgetEventSchema.safeParse({ type: 'task/status', status: 'in_progress' });
+    expect(result.success).toBe(false);
   });
 });


### PR DESCRIPTION
Part of a workspace-wide terminology + stale-code cleanup (audit pass).

The status-mapping test hardcoded SIM/QA status literals (including the retired `needs_healing`) and asserted them against themselves. Keeps only the real `WidgetEventSchema` validation tests. SDK mirror comment re-synced from api.

**Verified:** code:check ✓, 220 tests ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015JWfa9GJvwJAQAmEFthrYj