### PR TITLE
refactor(widget): rename task→simulation (cosmetic)

### DIFF
--- a/src/components/MarketrixWidget.tsx
+++ b/src/components/MarketrixWidget.tsx
@@ -138,7 +138,7 @@ export const MarketrixWidget: React.FC<MarketrixWidgetProps> = ({ config }) => {
     show_widget: config.show_widget,
     use_screenshare: config.use_screenshare,
   };
-  const showProcessingFeedback = state.isLoading || state.isTaskRunning;
+  const showProcessingFeedback = state.isLoading || state.isSimulationRunning;
   const customStyles = {
     ...semanticTokenStyles,
     '--widget-z-index': effectiveWidgetZIndex,
@@ -171,7 +171,7 @@ export const MarketrixWidget: React.FC<MarketrixWidgetProps> = ({ config }) => {
           isMinimized={state.isMinimized}
           messages={state.messages}
           currentMode={state.currentMode}
-          isTaskRunning={state.isTaskRunning}
+          isSimulationRunning={state.isSimulationRunning}
           activeView={state.activeView}
           onClose={actions.closeWidget}
           onSendMessage={actions.sendMessage}
@@ -189,7 +189,7 @@ export const MarketrixWidget: React.FC<MarketrixWidgetProps> = ({ config }) => {
         open={state.isOpen}
         processing={state.isLoading}
         error={!!state.error}
-        taskRunning={state.isTaskRunning}
+        taskRunning={state.isSimulationRunning}
         onClick={actions.toggleWidget}
         onStop={actions.stopTask}
         accentColor={effectiveConfig.widget_accent_color}

--- a/src/components/blocks/ChatInput.tsx
+++ b/src/components/blocks/ChatInput.tsx
@@ -141,7 +141,7 @@ export const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(f
           variant={taskRunning ? 'secondary' : 'primary'}
           size='sm'
           disabled={!taskRunning && !canSend}
-          label={taskRunning ? 'Stop task' : 'Send message'}
+          label={taskRunning ? 'Stop simulation' : 'Send message'}
           onClick={e => {
             e.preventDefault();
             e.stopPropagation();

--- a/src/components/blocks/WidgetFab.tsx
+++ b/src/components/blocks/WidgetFab.tsx
@@ -115,7 +115,7 @@ export const WidgetFab: React.FC<WidgetFabProps> = ({
             }}
             className={`absolute top-1/2 z-20 -translate-y-1/2 rounded-full border border-white/25 bg-gray-900 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide text-white shadow-lg opacity-0 transition-opacity duration-150 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto ${position.includes('left') ? 'left-full ml-2' : 'right-full mr-2'}`}
             style={{ border: '1px solid rgba(255,255,255,0.25)' }}
-            aria-label='Stop running task'
+            aria-label='Stop simulation'
           >
             Stop
           </Button>

--- a/src/components/chat/MessageContent.tsx
+++ b/src/components/chat/MessageContent.tsx
@@ -49,7 +49,7 @@ export const MessageContent: React.FC<MessageContentProps> = ({ message, isLastM
             );
           } else if (part.type === 'progress') {
             // Hide progress line for "done" tool when task is completed (show icon instead)
-            if (part.toolName === 'done' && message.taskStatus === 'done') {
+            if (part.toolName === 'done' && message.simulationStatus === 'done') {
               return null;
             }
 
@@ -67,7 +67,7 @@ export const MessageContent: React.FC<MessageContentProps> = ({ message, isLastM
         })}
 
         {((message.isPlaceholder && !message.parts.some(p => p.type === 'text')) ||
-          (widgetState.isTaskRunning && isLastMessage && (message.mode === 'show' || message.mode === 'do'))) && (
+          (widgetState.isSimulationRunning && isLastMessage && (message.mode === 'show' || message.mode === 'do'))) && (
           <ThinkingIndicator isWaitingForUser={isWaitingForUser} />
         )}
       </Stack>
@@ -76,7 +76,7 @@ export const MessageContent: React.FC<MessageContentProps> = ({ message, isLastM
 
   if (
     message.isPlaceholder ||
-    (widgetState.isTaskRunning && isLastMessage && (message.mode === 'show' || message.mode === 'do'))
+    (widgetState.isSimulationRunning && isLastMessage && (message.mode === 'show' || message.mode === 'do'))
   ) {
     return <ThinkingIndicator isWaitingForUser={isWaitingForUser} />;
   }

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -9,7 +9,7 @@ import { Flex } from '../base/Flex';
 import { Stack } from '../base/Stack';
 import { Text } from '../base/Text';
 import { MessageContent } from './MessageContent';
-import { TaskStatusIcon } from './TaskStatusIcon';
+import { SimulationStatusIcon } from './SimulationStatusIcon';
 import { VideoStreamDisplay } from './VideoStreamDisplay';
 
 interface MessageItemProps {
@@ -99,9 +99,9 @@ export const MessageItem: React.FC<MessageItemProps> = ({
             </Text>
           )}
 
-          {!isUser && message.taskStatus && (
+          {!isUser && message.simulationStatus && (
             <Flex position='absolute' align='center' justify='center' style={{ bottom: '4px', right: '4px' }}>
-              <TaskStatusIcon status={message.taskStatus} />
+              <SimulationStatusIcon status={message.simulationStatus} />
             </Flex>
           )}
         </Stack>

--- a/src/components/chat/SimulationStatusIcon.tsx
+++ b/src/components/chat/SimulationStatusIcon.tsx
@@ -5,11 +5,11 @@ import { addOpacity } from '../../utils/color';
 import { Icon } from '../base/Icon';
 import { Spinner } from '../base/Spinner';
 
-interface TaskStatusIconProps {
+interface SimulationStatusIconProps {
   status: 'ongoing' | 'done' | 'failed' | 'stopped';
 }
 
-export const TaskStatusIcon: React.FC<TaskStatusIconProps> = ({ status }) => {
+export const SimulationStatusIcon: React.FC<SimulationStatusIconProps> = ({ status }) => {
   const { config: widgetConfig } = useWidget();
   const accentColor = widgetConfig.widget_accent_color;
   const iconSize = 14;

--- a/src/components/navigation/MessengerShell.tsx
+++ b/src/components/navigation/MessengerShell.tsx
@@ -26,7 +26,7 @@ export interface MessengerShellProps {
   isMinimized: boolean;
   messages: ChatMessage[];
   currentMode: InstructionType;
-  isTaskRunning?: boolean;
+  isSimulationRunning?: boolean;
   activeView: WidgetView;
   onClose: () => void;
   onSendMessage: (
@@ -52,7 +52,7 @@ export const MessengerShell: React.FC<MessengerShellProps> = ({
   isMinimized,
   messages,
   currentMode,
-  isTaskRunning = false,
+  isSimulationRunning = false,
   activeView,
   onClose,
   onSendMessage,
@@ -214,7 +214,7 @@ export const MessengerShell: React.FC<MessengerShellProps> = ({
                   config={config}
                   messages={messages}
                   currentMode={currentMode}
-                  isTaskRunning={isTaskRunning}
+                  isSimulationRunning={isSimulationRunning}
                   onSendMessage={onSendMessage}
                   onSetMode={onSetMode}
                   onAddMessage={onAddMessage}

--- a/src/components/views/ChatView.tsx
+++ b/src/components/views/ChatView.tsx
@@ -44,7 +44,7 @@ export interface ChatViewProps {
   config: MarketrixConfig;
   messages: ChatMessage[];
   currentMode: InstructionType;
-  isTaskRunning?: boolean;
+  isSimulationRunning?: boolean;
   onSendMessage: (
     message: string,
     mode?: InstructionType,
@@ -92,7 +92,7 @@ export const ChatView: React.FC<ChatViewProps> = ({
   config,
   messages,
   currentMode,
-  isTaskRunning = false,
+  isSimulationRunning = false,
   onSendMessage,
   onSetMode,
   onAddMessage,
@@ -211,7 +211,7 @@ export const ChatView: React.FC<ChatViewProps> = ({
           activeMode={currentMode}
           onModeChange={mode => handleModeChange(mode as InstructionType)}
           disabled={messages.some(msg => msg.isPlaceholder)}
-          taskRunning={isTaskRunning}
+          taskRunning={isSimulationRunning}
           onStop={() => {
             showModeService.cleanup();
             onStopTask?.();

--- a/src/context/ConversationContext.tsx
+++ b/src/context/ConversationContext.tsx
@@ -24,9 +24,9 @@ import type { UIStateActions } from './UIStateContext';
  * concern.
  */
 
-export interface TaskState {
-  activeTaskId: string | null;
-  isTaskRunning: boolean;
+export interface SimulationState {
+  activeSimulationId: string | null;
+  isSimulationRunning: boolean;
 }
 
 export interface ChatState {
@@ -48,21 +48,21 @@ export interface ChatActions {
   ) => Promise<void>;
 }
 
-export interface TaskActions {
-  setTaskState: (payload: { activeTaskId: string | null; isTaskRunning: boolean }) => void;
+export interface SimulationActions {
+  setTaskState: (payload: { activeSimulationId: string | null; isSimulationRunning: boolean }) => void;
   stopTask: () => Promise<void>;
 }
 
 interface ConversationContextType {
   chatState: ChatState;
   chatActions: ChatActions;
-  taskState: TaskState;
-  taskActions: TaskActions;
+  taskState: SimulationState;
+  taskActions: SimulationActions;
 }
 
 const ConversationContext = createContext<ConversationContextType | undefined>(undefined);
 
-const EMPTY_TASK: TaskState = { activeTaskId: null, isTaskRunning: false };
+const EMPTY_TASK: SimulationState = { activeSimulationId: null, isSimulationRunning: false };
 
 interface ConversationProviderProps {
   children: React.ReactNode;
@@ -73,7 +73,7 @@ interface ConversationProviderProps {
   uiActions: Pick<UIStateActions, 'setLoading' | 'setAgentAvailable' | 'setError'>;
   /** One-time hydrated snapshot to seed the store (messages + task) on mount. */
   initialMessages?: ChatMessage[];
-  initialTask?: TaskState;
+  initialTask?: SimulationState;
 }
 
 export const ConversationProvider: React.FC<ConversationProviderProps> = ({
@@ -148,8 +148,11 @@ export const ConversationProvider: React.FC<ConversationProviderProps> = ({
   }, [commit]);
 
   const setTaskState = useCallback(
-    (payload: { activeTaskId: string | null; isTaskRunning: boolean }) => {
-      commit(s => ({ ...s, task: { activeTaskId: payload.activeTaskId, isTaskRunning: payload.isTaskRunning } }));
+    (payload: { activeSimulationId: string | null; isSimulationRunning: boolean }) => {
+      commit(s => ({
+        ...s,
+        task: { activeSimulationId: payload.activeSimulationId, isSimulationRunning: payload.isSimulationRunning },
+      }));
     },
     [commit],
   );
@@ -272,7 +275,7 @@ export const ConversationProvider: React.FC<ConversationProviderProps> = ({
     if (p.apiTaskId && p.agentRunning) {
       const taskId = p.apiTaskId;
       pendingTaskRef.current = {};
-      commit(s => ({ ...s, task: { isTaskRunning: true, activeTaskId: taskId } }));
+      commit(s => ({ ...s, task: { isSimulationRunning: true, activeSimulationId: taskId } }));
     }
   }, [commit]);
 
@@ -290,9 +293,6 @@ export const ConversationProvider: React.FC<ConversationProviderProps> = ({
       for (const effect of effects) {
         if (effect.type === 'setLoading') {
           uiActions.setLoading(effect.value);
-        } else if (effect.type === 'activateApiTask') {
-          pendingTaskRef.current = { ...pendingTaskRef.current, apiTaskId: effect.taskId };
-          maybeActivateTask();
         }
       }
     };
@@ -370,7 +370,7 @@ export const ConversationProvider: React.FC<ConversationProviderProps> = ({
           return;
         }
 
-        if (!stateRef.current.task.isTaskRunning) {
+        if (!stateRef.current.task.isSimulationRunning) {
           console.log('[Widget] Tool call received before task/status running — auto-activating task');
         }
         if (event.state_version !== undefined && event.state_version > stateVersion.current) {
@@ -421,7 +421,7 @@ export const ConversationProvider: React.FC<ConversationProviderProps> = ({
   }, [previewMode, commit, maybeActivateTask, addProcessedRequestId, uiActions]);
 
   const stopTask = useCallback(async () => {
-    const taskId = stateRef.current.task.activeTaskId ?? undefined;
+    const taskId = stateRef.current.task.activeSimulationId ?? undefined;
     commit(s => reduceStop(s, currentModeRef.current));
 
     if (previewMode) return;
@@ -436,7 +436,7 @@ export const ConversationProvider: React.FC<ConversationProviderProps> = ({
     [addMessage, updateMessage, removeMessage, setMessages, clearMessages, sendMessage],
   );
 
-  const taskActions = useMemo<TaskActions>(() => ({ setTaskState, stopTask }), [setTaskState, stopTask]);
+  const taskActions = useMemo<SimulationActions>(() => ({ setTaskState, stopTask }), [setTaskState, stopTask]);
 
   const chatState = useMemo<ChatState>(() => ({ messages: state.messages }), [state.messages]);
 

--- a/src/context/WidgetProviders.tsx
+++ b/src/context/WidgetProviders.tsx
@@ -27,8 +27,8 @@ const PersistBridge: React.FC<{ previewMode: boolean }> = ({ previewMode }) => {
     if (previewMode) return;
     chatService.persist({
       messages: chatState.messages,
-      isTaskRunning: taskState.isTaskRunning,
-      activeTaskId: taskState.activeTaskId,
+      isSimulationRunning: taskState.isSimulationRunning,
+      activeSimulationId: taskState.activeSimulationId,
       currentMode: uiState.currentMode,
       isOpen: uiState.isOpen,
       isMinimized: uiState.isMinimized,
@@ -37,8 +37,8 @@ const PersistBridge: React.FC<{ previewMode: boolean }> = ({ previewMode }) => {
   }, [
     previewMode,
     chatState.messages,
-    taskState.isTaskRunning,
-    taskState.activeTaskId,
+    taskState.isSimulationRunning,
+    taskState.activeSimulationId,
     uiState.currentMode,
     uiState.isOpen,
     uiState.isMinimized,
@@ -80,8 +80,8 @@ const InitBridge: React.FC<{ children: React.ReactNode; previewMode: boolean }> 
 
       chatActions.setMessages(snapshot.messages);
       taskActions.setTaskState({
-        activeTaskId: snapshot.isTaskRunning ? snapshot.activeTaskId : null,
-        isTaskRunning: snapshot.isTaskRunning,
+        activeSimulationId: snapshot.isSimulationRunning ? snapshot.activeSimulationId : null,
+        isSimulationRunning: snapshot.isSimulationRunning,
       });
 
       if (chatId) {

--- a/src/context/__tests__/sseReducer.test.ts
+++ b/src/context/__tests__/sseReducer.test.ts
@@ -28,12 +28,12 @@ const agentMessage = (overrides: Partial<ChatMessage> = {}): ChatMessage => ({
 
 const runningState = (overrides: Partial<ChatMessage> = {}): SseState => ({
   messages: [agentMessage(overrides)],
-  task: { activeTaskId: 'task-1', isTaskRunning: true },
+  task: { activeSimulationId: 'task-1', isSimulationRunning: true },
 });
 
 const idleState = (): SseState => ({
   messages: [agentMessage({ placeholderState: undefined })],
-  task: { activeTaskId: null, isTaskRunning: false },
+  task: { activeSimulationId: null, isSimulationRunning: false },
 });
 
 // task/status
@@ -57,20 +57,20 @@ describe('reduceSse — task/status', () => {
 
   it('completed ends the task and marks the active message done', () => {
     const result = reduceSse(runningState(), { type: 'task/status', status: 'completed' }, 'do');
-    expect(result.state.task).toEqual({ isTaskRunning: false, activeTaskId: null });
-    expect(result.state.messages[0].taskStatus).toBe('done');
+    expect(result.state.task).toEqual({ isSimulationRunning: false, activeSimulationId: null });
+    expect(result.state.messages[0].simulationStatus).toBe('done');
   });
 
   it('failed ends the task and marks the active message failed', () => {
     const result = reduceSse(runningState(), { type: 'task/status', status: 'failed' }, 'do');
-    expect(result.state.task.isTaskRunning).toBe(false);
-    expect(result.state.messages[0].taskStatus).toBe('failed');
+    expect(result.state.task.isSimulationRunning).toBe(false);
+    expect(result.state.messages[0].simulationStatus).toBe('failed');
   });
 
   it('stopped ends the task and marks the active message stopped', () => {
     const result = reduceSse(runningState(), { type: 'task/status', status: 'stopped' }, 'do');
-    expect(result.state.task.isTaskRunning).toBe(false);
-    expect(result.state.messages[0].taskStatus).toBe('stopped');
+    expect(result.state.task.isSimulationRunning).toBe(false);
+    expect(result.state.messages[0].simulationStatus).toBe('stopped');
   });
 
   it('terminal status overwrites content when the event carries a message', () => {
@@ -79,7 +79,7 @@ describe('reduceSse — task/status', () => {
     expect(result.state.messages[0].content).toBe('All done!');
   });
 
-  it('has_question pauses (not terminal): clears spinner, flips to waiting-for-user, no taskStatus', () => {
+  it('has_question pauses (not terminal): clears spinner, flips to waiting-for-user, no simulationStatus', () => {
     const before = runningState();
     expect(hasThinkingMarker(before.messages[0].content)).toBe(true);
 
@@ -91,8 +91,8 @@ describe('reduceSse — task/status', () => {
     expect(msg.placeholderState).toBe('waiting-for-user');
     expect(msg.content).toContain('Which account?');
     // Paused, not finished — no terminal icon.
-    expect(msg.taskStatus).toBeUndefined();
-    expect(result.state.task).toEqual({ isTaskRunning: false, activeTaskId: null });
+    expect(msg.simulationStatus).toBeUndefined();
+    expect(result.state.task).toEqual({ isSimulationRunning: false, activeSimulationId: null });
   });
 });
 
@@ -125,7 +125,7 @@ describe('reduceSse — tool/call', () => {
 
   it('auto-activates the task when a tool arrives before task/status running', () => {
     const result = reduceSse(idleState(), toolCall(), 'do');
-    expect(result.state.task.isTaskRunning).toBe(true);
+    expect(result.state.task.isSimulationRunning).toBe(true);
   });
 
   it('adds an in-progress progress line to the active message', () => {
@@ -149,7 +149,7 @@ describe('reduceSse — chat/response', () => {
   it('resolves the matching placeholder and turns off loading', () => {
     const state: SseState = {
       messages: [agentMessage({ id: 'req-1', content: '\n\n__THINKING__', parts: [] })],
-      task: { activeTaskId: null, isTaskRunning: false },
+      task: { activeSimulationId: null, isSimulationRunning: false },
     };
     const event: WidgetEvent = { type: 'chat/response', request_id: 'req-1', text: 'Here you go' };
     const result = reduceSse(state, event, 'tell');
@@ -161,23 +161,13 @@ describe('reduceSse — chat/response', () => {
     expect(msg.parts?.at(-1)).toEqual({ type: 'text', content: 'Here you go' });
     expect(result.effects).toContainEqual({ type: 'setLoading', value: false });
   });
-
-  it('adds an activateApiTask effect when the response carries a task_id', () => {
-    const state: SseState = {
-      messages: [agentMessage({ id: 'req-1' })],
-      task: { activeTaskId: null, isTaskRunning: false },
-    };
-    const event: WidgetEvent = { type: 'chat/response', request_id: 'req-1', text: 'ok', task_id: 'task-7' };
-    const result = reduceSse(state, event, 'tell');
-    expect(result.effects).toContainEqual({ type: 'activateApiTask', taskId: 'task-7' });
-  });
 });
 
 describe('reduceSse — chat/error', () => {
   it('writes an error message into the matching placeholder and turns off loading', () => {
     const state: SseState = {
       messages: [agentMessage({ id: 'req-2' })],
-      task: { activeTaskId: null, isTaskRunning: false },
+      task: { activeSimulationId: null, isSimulationRunning: false },
     };
     const event: WidgetEvent = { type: 'chat/error', request_id: 'req-2', error: 'boom' };
     const result = reduceSse(state, event, 'tell');
@@ -249,17 +239,17 @@ describe('reduceToolProgress / reduceToolDone / reduceStop', () => {
           ],
         }),
       ],
-      task: { activeTaskId: 'task-1', isTaskRunning: true },
+      task: { activeSimulationId: 'task-1', isSimulationRunning: true },
     };
     const result = reduceToolDone(withDoneLine, 'do');
-    expect(result.task).toEqual({ isTaskRunning: false, activeTaskId: null });
-    expect(result.messages[0].taskStatus).toBe('done');
+    expect(result.task).toEqual({ isSimulationRunning: false, activeSimulationId: null });
+    expect(result.messages[0].simulationStatus).toBe('done');
     expect((result.messages[0].parts ?? []).some(p => p.type === 'progress' && p.toolName === 'done')).toBe(false);
   });
 
   it('reduceStop marks the active message stopped and ends the task', () => {
     const result = reduceStop(runningState(), 'do');
-    expect(result.messages[0].taskStatus).toBe('stopped');
-    expect(result.task).toEqual({ isTaskRunning: false, activeTaskId: null });
+    expect(result.messages[0].simulationStatus).toBe('stopped');
+    expect(result.task).toEqual({ isSimulationRunning: false, activeSimulationId: null });
   });
 });

--- a/src/context/sseReducer.ts
+++ b/src/context/sseReducer.ts
@@ -20,14 +20,14 @@ import {
   WAIT_FOR_USER_TOOLS,
 } from '../utils/chat';
 
-export interface SseTaskState {
-  activeTaskId: string | null;
-  isTaskRunning: boolean;
+export interface SseSimulationState {
+  activeSimulationId: string | null;
+  isSimulationRunning: boolean;
 }
 
 export interface SseState {
   messages: ChatMessage[];
-  task: SseTaskState;
+  task: SseSimulationState;
 }
 
 /** Side effects the wiring layer must run after applying a reduced state. */
@@ -40,8 +40,7 @@ export type SseEffect =
       mode: InstructionType;
       explanation: string;
     }
-  | { type: 'setLoading'; value: boolean }
-  | { type: 'activateApiTask'; taskId: string };
+  | { type: 'setLoading'; value: boolean };
 
 export interface ReduceResult {
   state: SseState;
@@ -57,7 +56,7 @@ type ProgressStatus = 'in_progress' | 'completed' | 'failed';
  */
 function applyProgress(
   messages: ChatMessage[],
-  isTaskRunning: boolean,
+  isSimulationRunning: boolean,
   currentMode: InstructionType,
   toolName: string,
   explanation: string,
@@ -67,14 +66,14 @@ function applyProgress(
   const friendlyName = getFriendlyToolName(toolName);
   const found = findMessageForProgress({
     messages,
-    isTaskRunning,
+    isSimulationRunning,
     currentMode,
     requireContent: status === 'failed',
   });
   if (!found) return messages;
 
   let updatedMsg = found.message;
-  const shouldWait = isTaskRunning && currentMode === 'show' && WAIT_FOR_USER_TOOLS.has(toolName);
+  const shouldWait = isSimulationRunning && currentMode === 'show' && WAIT_FOR_USER_TOOLS.has(toolName);
   const isDoneTool = toolName === 'done';
   const isShowOrDo = currentMode === 'show' || currentMode === 'do';
 
@@ -82,20 +81,20 @@ function applyProgress(
     if (!isDoneTool) {
       updatedMsg = addProgressLine(updatedMsg, friendlyName, explanation || friendlyName);
     }
-    if (isTaskRunning && isShowOrDo) {
-      updatedMsg = updateThinkingMarker(updatedMsg, isTaskRunning, currentMode, shouldWait);
+    if (isSimulationRunning && isShowOrDo) {
+      updatedMsg = updateThinkingMarker(updatedMsg, isSimulationRunning, currentMode, shouldWait);
     }
   } else if (status === 'completed') {
     if (!isDoneTool) {
       updatedMsg = markProgressLineComplete(updatedMsg);
     }
-    if (isTaskRunning && isShowOrDo) {
-      updatedMsg = updateThinkingMarker(updatedMsg, isTaskRunning, currentMode, false);
+    if (isSimulationRunning && isShowOrDo) {
+      updatedMsg = updateThinkingMarker(updatedMsg, isSimulationRunning, currentMode, false);
     }
   } else {
     updatedMsg = markProgressLineFailed(updatedMsg, friendlyName, error || '');
-    if (isTaskRunning && isShowOrDo) {
-      updatedMsg = updateThinkingMarker(updatedMsg, isTaskRunning, currentMode, false);
+    if (isSimulationRunning && isShowOrDo) {
+      updatedMsg = updateThinkingMarker(updatedMsg, isSimulationRunning, currentMode, false);
     }
   }
 
@@ -117,7 +116,7 @@ export function reduceToolProgress(
     ...state,
     messages: applyProgress(
       state.messages,
-      state.task.isTaskRunning,
+      state.task.isSimulationRunning,
       currentMode,
       toolName,
       explanation,
@@ -131,7 +130,7 @@ export function reduceToolProgress(
 export function reduceToolDone(state: SseState, currentMode: InstructionType): SseState {
   const found = findMessageForProgress({
     messages: state.messages,
-    isTaskRunning: state.task.isTaskRunning,
+    isSimulationRunning: state.task.isSimulationRunning,
     currentMode,
     requireContent: false,
   });
@@ -140,24 +139,24 @@ export function reduceToolDone(state: SseState, currentMode: InstructionType): S
     const updatedParts = (found.message.parts ?? []).filter(
       part => !(part.type === 'progress' && part.toolName === 'done'),
     );
-    messages[found.index] = { ...found.message, taskStatus: 'done', parts: updatedParts };
+    messages[found.index] = { ...found.message, simulationStatus: 'done', parts: updatedParts };
   }
-  return { messages, task: { isTaskRunning: false, activeTaskId: null } };
+  return { messages, task: { isSimulationRunning: false, activeSimulationId: null } };
 }
 
 /** Public: user-initiated stop — flag the active message `stopped` and end the task. */
 export function reduceStop(state: SseState, currentMode: InstructionType): SseState {
   const found = findMessageForProgress({
     messages: state.messages,
-    isTaskRunning: state.task.isTaskRunning,
+    isSimulationRunning: state.task.isSimulationRunning,
     currentMode,
     requireContent: false,
   });
   const messages = [...state.messages];
   if (found) {
-    messages[found.index] = { ...found.message, taskStatus: 'stopped' };
+    messages[found.index] = { ...found.message, simulationStatus: 'stopped' };
   }
-  return { messages, task: { isTaskRunning: false, activeTaskId: null } };
+  return { messages, task: { isSimulationRunning: false, activeSimulationId: null } };
 }
 
 /**
@@ -168,13 +167,13 @@ export function reduceSse(state: SseState, event: WidgetEvent, currentMode: Inst
   switch (event.type) {
     case 'tool/call': {
       // Auto-activate the task if a tool arrives before `task/status running`.
-      const task = state.task.isTaskRunning ? state.task : { ...state.task, isTaskRunning: true };
-      const isTaskRunning = task.isTaskRunning;
+      const task = state.task.isSimulationRunning ? state.task : { ...state.task, isSimulationRunning: true };
+      const isSimulationRunning = task.isSimulationRunning;
       const mode = event.mode || currentMode || 'do';
       const explanation = event.explanation || '';
       const messages = applyProgress(
         state.messages,
-        isTaskRunning,
+        isSimulationRunning,
         currentMode,
         event.tool,
         explanation,
@@ -198,10 +197,10 @@ export function reduceSse(state: SseState, event: WidgetEvent, currentMode: Inst
       }
       if (event.status === 'has_question') {
         // Paused awaiting a user answer — not terminal. Stop the spinner and flip
-        // the active message to "waiting for you", leaving taskStatus unset.
+        // the active message to "waiting for you", leaving simulationStatus unset.
         const found = findMessageForProgress({
           messages: state.messages,
-          isTaskRunning: state.task.isTaskRunning,
+          isSimulationRunning: state.task.isSimulationRunning,
           currentMode,
           requireContent: false,
         });
@@ -214,27 +213,27 @@ export function reduceSse(state: SseState, event: WidgetEvent, currentMode: Inst
             ...(statusMessage && { content: statusMessage }),
           };
         }
-        return { state: { messages, task: { isTaskRunning: false, activeTaskId: null } }, effects: [] };
+        return { state: { messages, task: { isSimulationRunning: false, activeSimulationId: null } }, effects: [] };
       }
       // completed | failed | stopped — terminal.
       const found = findMessageForProgress({
         messages: state.messages,
-        isTaskRunning: state.task.isTaskRunning,
+        isSimulationRunning: state.task.isSimulationRunning,
         currentMode,
         requireContent: false,
       });
       const messages = [...state.messages];
       if (found) {
-        let taskStatus: 'done' | 'failed' | 'stopped' = 'done';
-        if (event.status === 'failed') taskStatus = 'failed';
-        else if (event.status === 'stopped') taskStatus = 'stopped';
+        let simulationStatus: 'done' | 'failed' | 'stopped' = 'done';
+        if (event.status === 'failed') simulationStatus = 'failed';
+        else if (event.status === 'stopped') simulationStatus = 'stopped';
         messages[found.index] = {
           ...found.message,
-          taskStatus,
+          simulationStatus,
           ...(statusMessage && { content: statusMessage }),
         };
       }
-      return { state: { messages, task: { isTaskRunning: false, activeTaskId: null } }, effects: [] };
+      return { state: { messages, task: { isSimulationRunning: false, activeSimulationId: null } }, effects: [] };
     }
 
     case 'chat/response': {
@@ -247,11 +246,9 @@ export function reduceSse(state: SseState, event: WidgetEvent, currentMode: Inst
           isPlaceholder: false,
           placeholderState: undefined,
           parts: newParts,
-          ...(event.task_id && { taskId: event.task_id }),
         };
       });
       const effects: SseEffect[] = [{ type: 'setLoading', value: false }];
-      if (event.task_id) effects.push({ type: 'activateApiTask', taskId: event.task_id });
       return { state: { ...state, messages }, effects };
     }
 

--- a/src/hooks/useWidget.ts
+++ b/src/hooks/useWidget.ts
@@ -33,7 +33,7 @@ interface UseWidgetActions {
   setAgentAvailable: (available: boolean) => void;
   setError: (error: string | undefined) => void;
   clearError: () => void;
-  setTaskState: (payload: { activeTaskId: string | null; isTaskRunning: boolean }) => void;
+  setTaskState: (payload: { activeSimulationId: string | null; isSimulationRunning: boolean }) => void;
   addMessage: (message: ChatMessage) => void;
   updateMessage: (messageId: string, updates: Partial<ChatMessage>) => void;
   removeMessage: (messageId: string) => void;
@@ -68,15 +68,15 @@ export const useWidget = ({ config }: UseWidgetProps = {}) => {
       error: uiState.error,
       activeView: uiState.activeView,
       messages: chatState.messages,
-      activeTaskId: taskState.activeTaskId,
-      isTaskRunning: taskState.isTaskRunning,
+      activeSimulationId: taskState.activeSimulationId,
+      isSimulationRunning: taskState.isSimulationRunning,
     }),
     [uiState, chatState, taskState],
   );
 
   const resetChat = useCallback(() => {
     chatActions.clearMessages();
-    taskActions.setTaskState({ activeTaskId: null, isTaskRunning: false });
+    taskActions.setTaskState({ activeSimulationId: null, isSimulationRunning: false });
     uiActions.setError(undefined);
   }, [chatActions, taskActions, uiActions]);
 

--- a/src/sdk/contracts/entities.ts
+++ b/src/sdk/contracts/entities.ts
@@ -116,31 +116,6 @@ export const VIEWPORT_DIMENSIONS: Record<ViewportName, { width: number; height: 
   mobile: { width: 393, height: 852 },
 };
 
-export const TaskDependencySchema = z.object({
-  task_id: z.string(),
-  condition: z.enum(['pass']).optional(),
-});
-export type TaskDependency = z.infer<typeof TaskDependencySchema>;
-
-/**
- * A single task within a simulation. Direct simulations have 1 task (the prompt).
- * QA simulations have N tasks (one per journey).
- */
-export const SimulationTaskEntrySchema = z.object({
-  task_id: z.string(),
-  title: z.string(),
-  instructions: z.string(),
-  status: z.enum(['pending', 'running', 'has_question', 'passed', 'failed', 'skipped', 'stopped']),
-  error_message: z.string().nullish(),
-  started_at: z.string().nullish(),
-  completed_at: z.string().nullish(),
-  order_index: z.number().int().nonnegative().default(0),
-  tab_id: z.string().nullish(),
-  step_count: z.number().int().nonnegative().default(0),
-  blocked_by: z.array(TaskDependencySchema).default([]),
-});
-export type SimulationTaskEntry = z.infer<typeof SimulationTaskEntrySchema>;
-
 export const SentimentSchema = z.enum(['positive', 'neutral', 'negative']);
 
 export const StepReactionSchema = z.object({
@@ -190,7 +165,9 @@ export const SimulationEntitySchema = BaseEntitySchema.extend({
   source: z.enum(['direct', 'qa']).optional(),
   graph_id: z.string().nullish(),
   source_metadata: z.record(z.string(), z.unknown()).nullish(),
-  tasks: z.array(SimulationTaskEntrySchema).optional(),
+  step_count: z.number().int().nonnegative().nullish(),
+  started_at: z.string().nullish(),
+  completed_at: z.string().nullish(),
   graph_status: GraphStatusSchema.optional(),
   graph_steps_processed: z.number().int().nonnegative().optional(),
   graph_steps_total: z.number().int().nonnegative().optional(),
@@ -379,7 +356,6 @@ export const SuggestedSimulationSchema = z.object({
   description: z.string(),
   selected: z.boolean(),
   simulation_id: z.number().nullable().optional(),
-  task_id: z.string().nullable().optional(),
   status: SimulationStatusSchema.nullable().optional(),
 });
 export type SuggestedSimulation = z.infer<typeof SuggestedSimulationSchema>;

--- a/src/sdk/contracts/widget.ts
+++ b/src/sdk/contracts/widget.ts
@@ -47,7 +47,6 @@ export const WidgetEventSchema = z.discriminatedUnion('type', [
     type: z.literal('chat/response'),
     request_id: z.string(),
     text: z.string(),
-    task_id: z.string().optional(),
   }),
   z.object({
     type: z.literal('chat/error'),
@@ -56,7 +55,7 @@ export const WidgetEventSchema = z.discriminatedUnion('type', [
   }),
   z.object({
     type: z.literal('task/status'),
-    // Matches SimulationTaskStatus / QATaskStatus on the agent side.
+    // Matches SimulationStatus on the agent side.
     status: z.enum(['running', 'completed', 'failed', 'stopped', 'has_question']),
     message: z.string().optional(),
     task_id: z.string().optional(),

--- a/src/services/ChatService.ts
+++ b/src/services/ChatService.ts
@@ -9,8 +9,8 @@ import { storageService } from './StorageService';
  */
 export interface ChatSnapshot {
   messages: ChatMessage[];
-  isTaskRunning: boolean;
-  activeTaskId: string | null;
+  isSimulationRunning: boolean;
+  activeSimulationId: string | null;
   currentMode: InstructionType;
   isOpen: boolean;
   isMinimized: boolean;
@@ -50,8 +50,8 @@ export class ChatService {
       storageService.updateContext({
         chat_id: chatId,
         messages: [],
-        isTaskRunning: false,
-        activeTaskId: null,
+        isSimulationRunning: false,
+        activeSimulationId: null,
         currentMode: 'tell',
         isOpen: false,
         isMinimized: false,
@@ -91,7 +91,7 @@ export class ChatService {
             timestamp: new Date(msg.timestamp),
             videoStream: undefined,
             placeholderState: msg.placeholderState,
-            taskStatus: msg.taskStatus,
+            simulationStatus: msg.simulationStatus,
             parts: msg.parts || [],
           };
 
@@ -108,8 +108,8 @@ export class ChatService {
 
     return {
       messages,
-      isTaskRunning: context.isTaskRunning,
-      activeTaskId: context.activeTaskId,
+      isSimulationRunning: context.isSimulationRunning,
+      activeSimulationId: context.activeSimulationId,
       currentMode: context.currentMode,
       isOpen: context.isOpen,
       isMinimized: context.isMinimized,
@@ -143,15 +143,15 @@ export class ChatService {
           isSystemMessage: msg.isSystemMessage,
           isPlaceholder: msg.isPlaceholder,
           placeholderState: msg.placeholderState,
-          taskStatus: msg.taskStatus,
+          simulationStatus: msg.simulationStatus,
           parts: msg.parts,
         }));
 
       storageService.updateContext({
         chat_id: this.chatId,
         messages: serializedMessages,
-        isTaskRunning: snapshot.isTaskRunning,
-        activeTaskId: snapshot.activeTaskId,
+        isSimulationRunning: snapshot.isSimulationRunning,
+        activeSimulationId: snapshot.activeSimulationId,
         currentMode: snapshot.currentMode,
         isOpen: snapshot.isOpen,
         isMinimized: snapshot.isMinimized,

--- a/src/services/StorageService.ts
+++ b/src/services/StorageService.ts
@@ -30,8 +30,8 @@ export interface MarketrixChatContext {
   chat_id: string | null;
 
   messages: StoredMessage[];
-  isTaskRunning: boolean;
-  activeTaskId: string | null;
+  isSimulationRunning: boolean;
+  activeSimulationId: string | null;
   currentMode: InstructionType;
   isOpen: boolean;
   isMinimized: boolean;
@@ -45,8 +45,8 @@ export interface MarketrixChatContext {
 const DEFAULT_CONTEXT: MarketrixChatContext = {
   chat_id: null,
   messages: [],
-  isTaskRunning: false,
-  activeTaskId: null,
+  isSimulationRunning: false,
+  activeSimulationId: null,
   currentMode: 'tell',
   isOpen: false,
   isMinimized: false,
@@ -181,12 +181,12 @@ class StorageService {
 
   getChatState(): Pick<
     MarketrixChatContext,
-    'isTaskRunning' | 'activeTaskId' | 'currentMode' | 'isOpen' | 'isMinimized' | 'isLoading'
+    'isSimulationRunning' | 'activeSimulationId' | 'currentMode' | 'isOpen' | 'isMinimized' | 'isLoading'
   > {
     const ctx = this.getContext();
     return {
-      isTaskRunning: ctx.isTaskRunning,
-      activeTaskId: ctx.activeTaskId,
+      isSimulationRunning: ctx.isSimulationRunning,
+      activeSimulationId: ctx.activeSimulationId,
       currentMode: ctx.currentMode,
       isOpen: ctx.isOpen,
       isMinimized: ctx.isMinimized,
@@ -198,7 +198,7 @@ class StorageService {
     state: Partial<
       Pick<
         MarketrixChatContext,
-        'isTaskRunning' | 'activeTaskId' | 'currentMode' | 'isOpen' | 'isMinimized' | 'isLoading'
+        'isSimulationRunning' | 'activeSimulationId' | 'currentMode' | 'isOpen' | 'isMinimized' | 'isLoading'
       >
     >,
   ): void {

--- a/src/services/__tests__/sse-event-handling.test.ts
+++ b/src/services/__tests__/sse-event-handling.test.ts
@@ -98,12 +98,6 @@ describe('SSE event discriminated-union contract (WidgetEventSchema)', () => {
       expect(WidgetEventSchema.safeParse({ type: 'chat/response', text: 'hi' }).success).toBe(false);
       expect(WidgetEventSchema.safeParse({ type: 'chat/response', request_id: 'r1', text: 'hi' }).success).toBe(true);
     });
-
-    it('task_id is optional', () => {
-      const base = { type: 'chat/response', request_id: 'r1', text: 'hi' };
-      expect(WidgetEventSchema.safeParse({ ...base, task_id: 'task-1' }).success).toBe(true);
-      expect(WidgetEventSchema.safeParse(base).success).toBe(true);
-    });
   });
 
   describe('task/status event', () => {
@@ -162,7 +156,7 @@ describe('SSE event discriminated-union contract (WidgetEventSchema)', () => {
   describe('task/status "has_question" pauses the active message (clears running spinner)', () => {
     // Mirrors the ConversationContext SSE reducer for `has_question`: strip the thinking
     // marker (kills the inline spinner) and flip to the paused "waiting for you"
-    // indicator without setting a terminal taskStatus icon.
+    // indicator without setting a terminal simulationStatus icon.
     const applyHasQuestionTransition = (message: ChatMessage, statusMessage?: string): ChatMessage => {
       const cleared = updateThinkingMarker(message, false, 'do');
       return {
@@ -179,7 +173,7 @@ describe('SSE event discriminated-union contract (WidgetEventSchema)', () => {
       timestamp: new Date(),
       mode: 'do',
       placeholderState: 'thinking',
-      taskStatus: 'ongoing',
+      simulationStatus: 'ongoing',
     });
 
     it('"has_question" is a valid SSE event that carries an optional message', () => {
@@ -199,9 +193,9 @@ describe('SSE event discriminated-union contract (WidgetEventSchema)', () => {
       const after = applyHasQuestionTransition(runningMessage());
       expect(after.placeholderState).toBe('waiting-for-user');
       // Terminal icon statuses must NOT be applied — the task is paused, not finished.
-      expect(after.taskStatus).not.toBe('done');
-      expect(after.taskStatus).not.toBe('failed');
-      expect(after.taskStatus).not.toBe('stopped');
+      expect(after.simulationStatus).not.toBe('done');
+      expect(after.simulationStatus).not.toBe('failed');
+      expect(after.simulationStatus).not.toBe('stopped');
     });
 
     it('surfaces the question text when the event includes a message', () => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -70,7 +70,7 @@ export interface ChatMessage {
   isPlaceholder?: boolean; // Indicates this is a placeholder message with progress bar
   placeholderState?: 'thinking' | 'waiting-for-user'; // State of placeholder: thinking or waiting for user action
   parts?: MessagePart[];
-  taskStatus?: 'ongoing' | 'done' | 'failed' | 'stopped'; // Task status indicator for task messages
+  simulationStatus?: 'ongoing' | 'done' | 'failed' | 'stopped'; // Simulation status indicator for agent messages
 }
 
 export interface MessagePart {
@@ -92,8 +92,8 @@ export interface WidgetState {
   currentMode: InstructionType;
   agentAvailable: boolean;
   error?: string;
-  activeTaskId: string | null;
-  isTaskRunning: boolean;
+  activeSimulationId: string | null;
+  isSimulationRunning: boolean;
   activeView: WidgetView;
 }
 

--- a/src/utils/chat.ts
+++ b/src/utils/chat.ts
@@ -47,14 +47,14 @@ function findTaskMessageIndex(messages: ChatMessage[]): number {
 
 export interface FindMessageOptions {
   messages: ChatMessage[];
-  isTaskRunning: boolean;
+  isSimulationRunning: boolean;
   currentMode: InstructionType;
   requireContent?: boolean;
 }
 
 function matchesProgressCriteria(
   msg: ChatMessage,
-  isTaskRunning: boolean,
+  isSimulationRunning: boolean,
   currentMode: InstructionType,
   requireContent: boolean | undefined,
   checkMode: boolean,
@@ -66,7 +66,7 @@ function matchesProgressCriteria(
   // For active show/do tasks, check mode matching
   // BUT: Be lenient for placeholders - allow mode mismatch if placeholder mode is undefined
   // This handles race conditions where tool calls arrive before mode is set
-  if (checkMode && isTaskRunning && (currentMode === 'show' || currentMode === 'do')) {
+  if (checkMode && isSimulationRunning && (currentMode === 'show' || currentMode === 'do')) {
     // For placeholders, allow mode mismatch if mode is undefined (will be set later)
     // For non-placeholders, require strict mode matching
     if (msg.isPlaceholder) {
@@ -110,17 +110,17 @@ export function findMessageForProgress(options: FindMessageOptions): {
   index: number;
   message: ChatMessage;
 } | null {
-  const { messages, isTaskRunning, currentMode, requireContent } = options;
+  const { messages, isSimulationRunning, currentMode, requireContent } = options;
   let taskMessageIndex = -1;
 
   // For active show/do tasks, find the message that matches the current mode and task state
-  if (isTaskRunning && (currentMode === 'show' || currentMode === 'do')) {
+  if (isSimulationRunning && (currentMode === 'show' || currentMode === 'do')) {
     const checkMode = true;
 
     // Priority 1: Find LAST placeholder with content in matching mode
     for (let i = messages.length - 1; i >= 0; i--) {
       const msg = messages[i];
-      const matchesCriteria = matchesProgressCriteria(msg, isTaskRunning, currentMode, requireContent, checkMode);
+      const matchesCriteria = matchesProgressCriteria(msg, isSimulationRunning, currentMode, requireContent, checkMode);
       const isPlaceholder = msg.isPlaceholder;
       const hasContent = !requireContent || msg.content.trim().length > 0 || (msg.parts && msg.parts.length > 0);
 
@@ -134,7 +134,13 @@ export function findMessageForProgress(options: FindMessageOptions): {
     if (taskMessageIndex < 0 && !requireContent) {
       for (let i = messages.length - 1; i >= 0; i--) {
         const msg = messages[i];
-        const matchesCriteria = matchesProgressCriteria(msg, isTaskRunning, currentMode, requireContent, checkMode);
+        const matchesCriteria = matchesProgressCriteria(
+          msg,
+          isSimulationRunning,
+          currentMode,
+          requireContent,
+          checkMode,
+        );
         const isPlaceholder = msg.isPlaceholder;
 
         if (matchesCriteria && isPlaceholder) {
@@ -148,7 +154,13 @@ export function findMessageForProgress(options: FindMessageOptions): {
     if (taskMessageIndex < 0) {
       for (let i = messages.length - 1; i >= 0; i--) {
         const msg = messages[i];
-        const matchesCriteria = matchesProgressCriteria(msg, isTaskRunning, currentMode, requireContent, checkMode);
+        const matchesCriteria = matchesProgressCriteria(
+          msg,
+          isSimulationRunning,
+          currentMode,
+          requireContent,
+          checkMode,
+        );
         const isPlaceholder = msg.isPlaceholder;
 
         if (matchesCriteria && !isPlaceholder) {
@@ -160,7 +172,7 @@ export function findMessageForProgress(options: FindMessageOptions): {
   }
 
   // Fallback: If not in active task or no matching message found, use general logic
-  // This is critical - tool calls can arrive before isTaskRunning is set to true
+  // This is critical - tool calls can arrive before isSimulationRunning is set to true
   if (taskMessageIndex < 0) {
     // Priority 1: Check LAST placeholder message (preferred for progress updates)
     // Don't require mode matching or content when task isn't running yet
@@ -215,7 +227,7 @@ export function findMessageForProgress(options: FindMessageOptions): {
 
   console.warn('[MessageFinder] No message found for progress update', {
     totalMessages: messages.length,
-    isTaskRunning,
+    isSimulationRunning,
     currentMode,
   });
   return null;
@@ -391,13 +403,13 @@ export function markProgressLineFailed(message: ChatMessage, toolName: string, e
 
 export function updateThinkingMarker(
   message: ChatMessage,
-  isTaskRunning: boolean,
+  isSimulationRunning: boolean,
   currentMode: 'show' | 'tell' | 'do',
   isWaitingForUser: boolean = false,
 ): ChatMessage {
   const msg = ensureMessageStructure(message);
 
-  if (!isTaskRunning || (currentMode !== 'show' && currentMode !== 'do')) {
+  if (!isSimulationRunning || (currentMode !== 'show' && currentMode !== 'do')) {
     if (hasThinkingMarker(msg.content)) {
       return {
         ...msg,


### PR DESCRIPTION
Part of the cross-repo **SimulationTask → Simulation collapse**. Merge **after api** (drift CI).

- Cosmetic rename (~130): `TaskState`→`SimulationState`, `activeTaskId`→`activeSimulationId`, `taskStatus`→`simulationStatus`, `TaskStatusIcon`→`SimulationStatusIcon`, etc.
- `chat/response` no longer carries `task_id` (dead `activateApiTask` path removed); SDK mirror resynced.

build + **218 tests** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)