### PR TITLE
chore(widget): re-sync SDK mirror (ActivityLog nullable)

### DIFF
--- a/src/sdk/contracts/entities.ts
+++ b/src/sdk/contracts/entities.ts
@@ -330,8 +330,9 @@ export const ActivityLogMetadataSchema = z
 export type ActivityLogMetadataData = z.infer<typeof ActivityLogMetadataSchema>;
 
 export const ActivityLogEntitySchema = BaseEntitySchema.extend({
-  workspace_id: z.number(),
-  user_id: z.number(),
+  // nullable: an audit-log entry outlives a deleted user/workspace (FK ON DELETE SET NULL, V120)
+  workspace_id: z.number().nullable(),
+  user_id: z.number().nullable(),
   type: ActivityLogTypeSchema,
   metadata: ActivityLogMetadataSchema.optional(),
 });


### PR DESCRIPTION
Mirror re-sync after api #790 made ActivityLog user_id/workspace_id nullable. Types-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)