### PR TITLE
chore(widget): re-sync SDK mirror (ActivityLog non-null)

### DIFF
--- a/src/sdk/contracts/entities.ts
+++ b/src/sdk/contracts/entities.ts
@@ -330,9 +330,8 @@ export const ActivityLogMetadataSchema = z
 export type ActivityLogMetadataData = z.infer<typeof ActivityLogMetadataSchema>;
 
 export const ActivityLogEntitySchema = BaseEntitySchema.extend({
-  // nullable: an audit-log entry outlives a deleted user/workspace (FK ON DELETE SET NULL, V120)
-  workspace_id: z.number().nullable(),
-  user_id: z.number().nullable(),
+  workspace_id: z.number(),
+  user_id: z.number(),
   type: ActivityLogTypeSchema,
   metadata: ActivityLogMetadataSchema.optional(),
 });


### PR DESCRIPTION
Reverts the #250 nullable mirror — api #791 made activity_log NOT NULL + CASCADE. Types-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)