### PR TITLE
chore(widget): re-sync SDK mirror — drop dead UserQuota export

### DIFF
--- a/src/sdk/contracts/entities.ts
+++ b/src/sdk/contracts/entities.ts
@@ -340,11 +340,3 @@ export type ActivityLogData = z.infer<typeof ActivityLogEntitySchema>;
 export const ActivityLogCreateSchema = ActivityLogEntitySchema.partial().extend({
   type: ActivityLogTypeSchema,
 });
-
-export const UserQuotaSchema = z.object({
-  user_id: z.number(),
-  limit: z.number(),
-  used: z.number(),
-  remaining: z.number(),
-});
-export type UserQuotaData = z.infer<typeof UserQuotaSchema>;


### PR DESCRIPTION
## What

Regenerated SDK mirror (`node api/scripts/sync-consumers.mjs widget`) to drop the dead `UserQuotaSchema`/`UserQuotaData` removed in **api Marketrix-ai/api#799**. Zero widget business-code consumers.

Touches only the generated mirror: `src/sdk/contracts/entities.ts` (−8 lines).

## Merge order

Pairs with Marketrix-ai/api#799 — **merge after api lands** (`contract-drift.yml` compares this mirror to api's default branch). Verified `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)