### PR TITLE
Regen SDK mirror for api seam cuts; drop dead pong references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,8 @@ Two typed oRPC procedures, both defined in `src/sdk/contracts/widget.ts`:
 
 Both payloads are Zod **discriminated unions on `type`**:
 
-- `WidgetEvent` (server→widget): `registered` (`chat_id`, `application_id?`), `pong`, `heartbeat`, `chat/response` (`request_id`, `text`, `task_id?`), `chat/error` (`request_id`, `error`), `task/status` (`status`, `message?`, `task_id?`, `timestamp?`), `tool/call` (`tool_call_id`, `browser_tool`, `args`, `mode?` `'show'|'do'`, `explanation?`, `state_version?`).
-- `WidgetCommand` (widget→server): `chat/tell`, `chat/show`, `chat/do` (each `request_id` + `content`), `chat/stop` (`task_id?`), `tool/response` (`tool_call_id`, `success`, `data?`, `error?`, `state_version?`), `ping`, `rrweb/metadata` (`rrweb_session_id`, …), `rrweb/events` (`rrweb_session_id`, …).
+- `WidgetEvent` (server→widget): `registered` (`chat_id`, `application_id?`), `heartbeat`, `chat/response` (`request_id`, `text`, `task_id?`), `chat/error` (`request_id`, `error`), `task/status` (`status`, `message?`, `task_id?`, `timestamp?`), `tool/call` (`tool_call_id`, `browser_tool`, `args`, `mode?` `'show'|'do'`, `explanation?`, `state_version?`).
+- `WidgetCommand` (widget→server): `chat/tell`, `chat/show`, `chat/do` (each `request_id` + `content`), `chat/stop` (`task_id?`), `tool/response` (`tool_call_id`, `success`, `data?`, `error?`, `state_version?`), `rrweb/metadata` (`rrweb_session_id`, …), `rrweb/events` (`rrweb_session_id`, …).
 
 **Transport** — `src/services/StreamClient.ts` is a singleton wrapping the oRPC `sdk`. It calls `sdk.widgetStream(input, { signal })` and drains the async iterator in the background. Status machine: `disconnected → connecting → connected → registered → error`. Exponential-backoff reconnect (1000 ms ×2, cap 30000 ms, **max 10 attempts**; counters reset only on a `registered` event). A `chat/error` whose `request_id === 'auth'` is **non-retriable** and permanently stops reconnection (until re-init). `heartbeat` is ignored. Sending uses `sdk.widgetMessage({ chat_id, command })`.
 

--- a/src/context/__tests__/sseReducer.test.ts
+++ b/src/context/__tests__/sseReducer.test.ts
@@ -181,7 +181,7 @@ describe('reduceSse — chat/error', () => {
 // ---------------------------------------------------------------------------
 
 describe('reduceSse — ignored events', () => {
-  it.each(['registered', 'pong', 'heartbeat'] as const)('%s is a no-op (same state, no effects)', type => {
+  it.each(['registered', 'heartbeat'] as const)('%s is a no-op (same state, no effects)', type => {
     const state = runningState();
     const event = { type, chat_id: 'c1' } as unknown as WidgetEvent;
     const result = reduceSse(state, event, 'do');

--- a/src/context/sseReducer.ts
+++ b/src/context/sseReducer.ts
@@ -161,7 +161,7 @@ export function reduceStop(state: SseState, currentMode: InstructionType): SseSt
 
 /**
  * Pure reducer. Returns the next state plus any side effects the wiring must run.
- * Unknown / non-stateful events (registered, pong, heartbeat) are ignored.
+ * Unknown / non-stateful events (registered, heartbeat) are ignored.
  */
 export function reduceSse(state: SseState, event: WidgetEvent, currentMode: InstructionType): ReduceResult {
   switch (event.type) {

--- a/src/sdk/contracts/application.ts
+++ b/src/sdk/contracts/application.ts
@@ -4,10 +4,6 @@ import { z } from 'zod';
 import { ByApplicationIdSchema, GraphSchema, paginatedListOf, PaginationSchema, SuccessSchema } from './common';
 import { ApplicationEntitySchema, ApplicationReadSchema, ApplicationTypeSchema, WidgetEntitySchema } from './entities';
 
-export const ApplicationFilterSchema = z.object({
-  application_id: z.coerce.number().optional(),
-});
-
 export const ApplicationCreateSchema = ApplicationEntitySchema.partial().extend({
   type: ApplicationTypeSchema,
   name: z.string().min(1),

--- a/src/sdk/contracts/common.ts
+++ b/src/sdk/contracts/common.ts
@@ -116,14 +116,3 @@ export const GraphSchema = z.object({
   edges: z.array(GraphEdgeSchema),
 });
 export type GraphData = z.infer<typeof GraphSchema>;
-
-/**
- * Skill invocation request — used by SimulationCreateSchema to launch a
- * simulation against a specific skill. Lives in common so simulation.ts
- * can import it without crossing domain boundaries.
- */
-export const SkillInvocationRequestSchema = z.object({
-  skill_id: z.number().int(),
-  params: z.record(z.string(), z.string()),
-});
-export type SkillInvocationRequest = z.infer<typeof SkillInvocationRequestSchema>;

--- a/src/sdk/contracts/entities.ts
+++ b/src/sdk/contracts/entities.ts
@@ -3,13 +3,11 @@ import { z } from 'zod';
 import { BaseEntitySchema, EntityStatusSchema } from './common';
 
 export const WorkspacePackageSchema = z.enum(['free', 'startup', 'growth', 'enterprise']);
-export type WorkspacePackage = z.infer<typeof WorkspacePackageSchema>;
 
 export const KnowledgeTypeSchema = z.enum(['document', 'video']);
 export type KnowledgeType = z.infer<typeof KnowledgeTypeSchema>;
 
 export const KnowledgeSourceSchema = z.enum(['user', 'research']);
-export type KnowledgeSource = z.infer<typeof KnowledgeSourceSchema>;
 
 // Canonical wire vocabulary matching the `simulation_status` Postgres ENUM and the
 // `SimulationStatus` proto enum.
@@ -26,8 +24,7 @@ export type SimulationStatus = z.infer<typeof SimulationStatusSchema>;
 
 /**
  * Graph generation lifecycle status on a simulation row. Values written by
- * `graphDispatch.ts` and `simulationHooks.ts`; relayed on the
- * `simulation/graph-updated` app event.
+ * `graphDispatch.ts` and `simulationHooks.ts`.
  */
 export const GraphStatusSchema = z.enum(['pending', 'generating', 'completed', 'failed']);
 
@@ -45,7 +42,7 @@ export type InstructionType = z.infer<typeof InstructionTypeSchema>;
  * password: Email/password authentication
  * oauth: Social login (Google, Microsoft, Apple, etc.) or SSO
  */
-export const AuthMethodSchema = z.enum(['password', 'oauth']);
+const AuthMethodSchema = z.enum(['password', 'oauth']);
 
 /**
  * Complete user entity schema
@@ -64,12 +61,6 @@ export const UserEntitySchema = BaseEntitySchema.extend({
   auth_method: AuthMethodSchema.nullish(),
 });
 export type UserData = z.infer<typeof UserEntitySchema>;
-
-export const UserCreateSchema = UserEntitySchema.partial().extend({
-  email: z.string().email(),
-  password: z.string(),
-});
-export type UserCreateData = z.infer<typeof UserCreateSchema>;
 
 /**
  * Complete workspace entity schema
@@ -327,7 +318,6 @@ export const ActivityLogMetadataSchema = z
     created_by: z.number().optional(),
   })
   .passthrough(); // Allow additional fields for flexibility (e.g., updatedData, previousData, createdData)
-export type ActivityLogMetadataData = z.infer<typeof ActivityLogMetadataSchema>;
 
 export const ActivityLogEntitySchema = BaseEntitySchema.extend({
   workspace_id: z.number(),

--- a/src/sdk/contracts/widget.ts
+++ b/src/sdk/contracts/widget.ts
@@ -2,21 +2,7 @@ import { eventIterator, oc } from '@orpc/contract';
 import { z } from 'zod';
 
 import { ByWidgetIdSchema, paginatedListOf, PaginationSchema } from './common';
-import {
-  ApplicationReadSchema,
-  UserEntitySchema,
-  WidgetEntitySchema,
-  WidgetSettingsDataSchema,
-  WidgetTypeSchema,
-  WorkspaceEntitySchema,
-} from './entities';
-
-export const WidgetInfoSchema = WidgetEntitySchema.extend({
-  application: ApplicationReadSchema.partial(),
-  workspace: WorkspaceEntitySchema.partial(),
-  user: UserEntitySchema.partial(),
-});
-export type WidgetInfoData = z.infer<typeof WidgetInfoSchema>;
+import { ApplicationReadSchema, WidgetEntitySchema, WidgetSettingsDataSchema, WidgetTypeSchema } from './entities';
 
 /**
  * Application with widgets schema — matches API response structure
@@ -41,7 +27,6 @@ export type WidgetSettingsKey = keyof z.infer<typeof WidgetSettingsDataSchema>;
 /** Server → Widget event (discriminated union on `type`) */
 export const WidgetEventSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('registered'), chat_id: z.string(), application_id: z.number().optional() }),
-  z.object({ type: z.literal('pong') }),
   z.object({ type: z.literal('heartbeat') }),
   z.object({
     type: z.literal('chat/response'),
@@ -87,7 +72,6 @@ export const WidgetCommandSchema = z.discriminatedUnion('type', [
     error: z.string().optional(),
     state_version: z.number().optional(),
   }),
-  z.object({ type: z.literal('ping') }),
   z.object({
     type: z.literal('rrweb/metadata'),
     rrweb_session_id: z.string(),

--- a/src/services/__tests__/sse-event-handling.test.ts
+++ b/src/services/__tests__/sse-event-handling.test.ts
@@ -13,7 +13,6 @@ import { hasThinkingMarker, updateThinkingMarker } from '@/utils/chat';
 // All event types present in the discriminated union — pin this set.
 const ALL_WIDGET_EVENT_TYPES = [
   'registered',
-  'pong',
   'heartbeat',
   'chat/response',
   'chat/error',
@@ -26,7 +25,6 @@ type ExpectedEventType = (typeof ALL_WIDGET_EVENT_TYPES)[number];
 /** Minimal valid fixtures for each event type */
 const MINIMAL_EVENT_FIXTURES: Record<ExpectedEventType, object> = {
   registered: { type: 'registered', chat_id: 'chat-001' },
-  pong: { type: 'pong' },
   heartbeat: { type: 'heartbeat' },
   'chat/response': { type: 'chat/response', request_id: 'req-1', text: 'Hello!' },
   'chat/error': { type: 'chat/error', request_id: 'req-2', error: 'Something went wrong' },
@@ -50,8 +48,8 @@ describe('SSE event discriminated-union contract (WidgetEventSchema)', () => {
       ).toBe(true);
     });
 
-    it('total distinct event types is 7 (regression guard — update if union changes)', () => {
-      expect(ALL_WIDGET_EVENT_TYPES).toHaveLength(7);
+    it('total distinct event types is 6 (regression guard — update if union changes)', () => {
+      expect(ALL_WIDGET_EVENT_TYPES).toHaveLength(6);
     });
   });
 


### PR DESCRIPTION
## What

Widget half of the seam debloat: SDK mirror regenerated from api #801 (ping/pong event pair + dead entity/common exports removed) + the widget-side pong no-op references (reducer comment, two test lists, event-count guard 7→6) and stale CLAUDE.md union lists. Net −43 LOC. Types-only at runtime — no widget deploy needed.

Merge **after** api #801 (contract-drift compares the mirror to api@dev).

## Verification

tsc clean · eslint clean · vitest 216/216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSfpjQC7RG5WtJgKR52v2R