### PR TITLE
chore(sdk): regen mirror — activity_log nullable ids (api#802)

### DIFF
--- a/src/sdk/contracts/entities.ts
+++ b/src/sdk/contracts/entities.ts
@@ -320,8 +320,8 @@ export const ActivityLogMetadataSchema = z
   .passthrough(); // Allow additional fields for flexibility (e.g., updatedData, previousData, createdData)
 
 export const ActivityLogEntitySchema = BaseEntitySchema.extend({
-  workspace_id: z.number(),
-  user_id: z.number(),
+  workspace_id: z.number().nullable(),
+  user_id: z.number().nullable(),
   type: ActivityLogTypeSchema,
   metadata: ActivityLogMetadataSchema.optional(),
 });


### PR DESCRIPTION
Generated mirror sync for api#802 (ActivityLog workspace_id/user_id nullable). Types-only, no deploy needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPio3SFBM3N1QzU5gpKe2a