### PR TITLE
feat(chat): render streamed tell replies (chat/delta)

### DIFF
--- a/src/context/__tests__/sseReducer.test.ts
+++ b/src/context/__tests__/sseReducer.test.ts
@@ -163,6 +163,42 @@ describe('reduceSse — chat/response', () => {
   });
 });
 
+describe('reduceSse — chat/delta', () => {
+  it('accumulates fragments into one streaming part and clears the placeholder', () => {
+    const state: SseState = {
+      messages: [agentMessage({ id: 'req-1', content: '\n\n__THINKING__', parts: [] })],
+      task: { activeSimulationId: null, isSimulationRunning: false },
+    };
+    const first = reduceSse(state, { type: 'chat/delta', request_id: 'req-1', text: 'Hel' }, 'tell');
+    const second = reduceSse(first.state, { type: 'chat/delta', request_id: 'req-1', text: 'lo' }, 'tell');
+
+    const msg = second.state.messages[0];
+    expect(msg.content).toBe('Hello');
+    expect(msg.isPlaceholder).toBe(false);
+    expect(msg.parts).toEqual([{ type: 'text', content: 'Hello', streaming: true }]);
+    // Still streaming — loading stays on until the final chat/response.
+    expect(second.effects).toEqual([]);
+  });
+
+  it('final chat/response replaces the streamed part (no duplication)', () => {
+    const state: SseState = {
+      messages: [agentMessage({ id: 'req-1', content: '\n\n__THINKING__', parts: [] })],
+      task: { activeSimulationId: null, isSimulationRunning: false },
+    };
+    const streamed = reduceSse(state, { type: 'chat/delta', request_id: 'req-1', text: 'Hello wor' }, 'tell');
+    const final = reduceSse(
+      streamed.state,
+      { type: 'chat/response', request_id: 'req-1', text: 'Hello world' },
+      'tell',
+    );
+
+    const msg = final.state.messages[0];
+    expect(msg.content).toBe('Hello world');
+    expect(msg.parts).toEqual([{ type: 'text', content: 'Hello world' }]);
+    expect(final.effects).toContainEqual({ type: 'setLoading', value: false });
+  });
+});
+
 describe('reduceSse — chat/error', () => {
   it('writes an error message into the matching placeholder and turns off loading', () => {
     const state: SseState = {

--- a/src/context/sseReducer.ts
+++ b/src/context/sseReducer.ts
@@ -243,16 +243,40 @@ export function reduceSse(state: SseState, event: WidgetEvent, currentMode: Inst
       return { state: { messages, task: { isSimulationRunning: false, activeSimulationId: null } }, effects: [] };
     }
 
+    case 'chat/delta': {
+      const messages = state.messages.map(msg => {
+        if (msg.id !== event.request_id) return msg;
+        const parts = [...(msg.parts ?? [])];
+        const last = parts[parts.length - 1];
+        if (last?.type === 'text' && last.streaming) {
+          parts[parts.length - 1] = { ...last, content: last.content + event.text };
+        } else {
+          parts.push({ type: 'text' as const, content: event.text, streaming: true });
+        }
+        const streamed = parts[parts.length - 1]!.content;
+        return { ...msg, content: streamed, isPlaceholder: false, placeholderState: undefined, parts };
+      });
+      return { state: { ...state, messages }, effects: [] };
+    }
+
     case 'chat/response': {
       const messages = state.messages.map(msg => {
         if (msg.id !== event.request_id) return msg;
-        const newParts = [...(msg.parts ?? []), { type: 'text' as const, content: event.text }];
+        // The final full text REPLACES an in-flight streamed part (chat/delta accumulation);
+        // otherwise it appends as its own part.
+        const parts = [...(msg.parts ?? [])];
+        const last = parts[parts.length - 1];
+        if (last?.type === 'text' && last.streaming) {
+          parts[parts.length - 1] = { type: 'text' as const, content: event.text };
+        } else {
+          parts.push({ type: 'text' as const, content: event.text });
+        }
         return {
           ...msg,
           content: event.text,
           isPlaceholder: false,
           placeholderState: undefined,
-          parts: newParts,
+          parts,
         };
       });
       const effects: SseEffect[] = [{ type: 'setLoading', value: false }];

--- a/src/sdk/contracts/entities.ts
+++ b/src/sdk/contracts/entities.ts
@@ -320,7 +320,7 @@ export const ActivityLogMetadataSchema = z
   .passthrough(); // Allow additional fields for flexibility (e.g., updatedData, previousData, createdData)
 
 export const ActivityLogEntitySchema = BaseEntitySchema.extend({
-  workspace_id: z.number().nullable(),
+  workspace_id: z.number(),
   user_id: z.number().nullable(),
   type: ActivityLogTypeSchema,
   metadata: ActivityLogMetadataSchema.optional(),

--- a/src/sdk/contracts/widget.ts
+++ b/src/sdk/contracts/widget.ts
@@ -34,6 +34,13 @@ export const WidgetEventSchema = z.discriminatedUnion('type', [
     text: z.string(),
   }),
   z.object({
+    // One streamed text fragment of the in-flight reply; the widget appends fragments and the
+    // final chat/response (the full text) replaces the accumulated stream.
+    type: z.literal('chat/delta'),
+    request_id: z.string(),
+    text: z.string(),
+  }),
+  z.object({
     type: z.literal('chat/error'),
     request_id: z.string(),
     error: z.string(),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -80,6 +80,9 @@ export interface MessagePart {
   browserToolName?: string;
   hideIcon?: boolean;
   textStyle?: 'default' | 'muted';
+  /** An in-flight streamed reply part — chat/delta fragments accumulate into it and the final
+   *  chat/response replaces it. */
+  streaming?: boolean;
 }
 
 export type WidgetView = 'home' | 'chat';


### PR DESCRIPTION
Widget half of response streaming (pairs with agent#780 + api#804):

- SDK mirror regen: `chat/delta` event + the activity_log id types (api#803/#804).
- `sseReducer`: `chat/delta` fragments accumulate into one **streaming** text part — the placeholder clears on the first delta so the reply renders progressively; the final `chat/response` **replaces** the streamed part (no duplicated block) and turns loading off.

Tests: 21 reducer tests green (2 new: accumulation + replace-on-final). Release order: agent → api → widget image+npm → app widget bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPio3SFBM3N1QzU5gpKe2a