### PR TITLE
fix(chat): run SSE transitions synchronously — deferred updaters dropped tool effects

### DIFF
--- a/src/context/ChatContext.tsx
+++ b/src/context/ChatContext.tsx
@@ -90,8 +90,9 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
   }));
 
   // Live snapshot for SSE wiring / stopTask that must not stale-close over state.
+  // commit() is the ONLY writer — never re-sync from render, or a stale render could
+  // regress the ref between a commit and its paint.
   const stateRef = useRef<SseState>(state);
-  stateRef.current = state;
 
   const currentModeRef = useRef(currentMode);
   currentModeRef.current = currentMode;
@@ -100,16 +101,17 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
   const processedRequestIds = useRef(new Set<string>());
   const pendingTaskRef = useRef<{ apiTaskId?: string; agentRunning?: boolean }>({});
 
-  // Run a pure transition against the live state and commit the result in ONE atomic setState.
-  // The reducer owns every message/task transition; reading through the functional updater keeps
-  // the snapshot current even mid-burst, and committing both fields together can never tear.
+  // Run a pure transition SYNCHRONOUSLY against the live snapshot, then publish for render.
+  // The transition must NOT run inside the setState updater: React defers updaters unless its
+  // queue is idle (never in a background tab or mid-burst), so effects captured from inside one
+  // are silently lost — tool calls arrived but never executed. stateRef is the synchronous source
+  // of truth (commit is the only writer); setState only notifies React.
   const commit = useCallback((transition: (s: SseState) => SseState) => {
-    setState(prev => {
-      const next = transition(prev);
-      if (next === prev || (next.messages === prev.messages && next.task === prev.task)) return prev;
-      stateRef.current = next;
-      return next;
-    });
+    const prev = stateRef.current;
+    const next = transition(prev);
+    if (next === prev || (next.messages === prev.messages && next.task === prev.task)) return;
+    stateRef.current = next;
+    setState(next);
   }, []);
 
   const addMessage = useCallback(


### PR DESCRIPTION
Final root cause of show/do 'widget not responding': `handleMessage` captured reducer effects from inside a `setState` updater. React only evaluates updaters eagerly when its update queue is idle — never in a background tab or mid-burst — so `runEffects` ran with `[]` and the tool was never executed. Matches all observed timing: tool responses only ever arrived ~0.4s after the tab was foregrounded.

`commit` now runs the transition synchronously against `stateRef` (single writer; render no longer re-syncs the ref) and `setState` only publishes the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPio3SFBM3N1QzU5gpKe2a