### PR TITLE
Widget side: SimulationReactionEntitySchema mirror regen + getWidgetSettings→getSettings

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -54,7 +54,7 @@ async function initializeWidgetWithConfig(
     const widgetService = new WidgetService(config.mtxId, config.mtxKey, config.mtxApp);
 
     const widgetData = await widgetService.widgetSettingsGet();
-    const widgetSettings = widgetData ? widgetService.getWidgetSettings(widgetData) : null;
+    const widgetSettings = widgetData ? widgetService.getSettings(widgetData) : null;
 
     if (!widgetSettings) {
       throw new Error('WidgetService did not return widget settings');

--- a/src/sdk/contracts/entities.ts
+++ b/src/sdk/contracts/entities.ts
@@ -114,7 +114,7 @@ export const StepReactionSchema = z.object({
 // One reactor's reaction to one simulation. run_id/user_index are null for a
 // direct sim's attached persona; set for a study persona-user. Shared by the
 // direct-sim read path AND the study replay.
-export const SimPersonaReactionEntitySchema = z.object({
+export const SimulationReactionEntitySchema = z.object({
   id: z.number(),
   run_id: z.number().nullable(),
   persona_id: z.number().nullable(),
@@ -164,7 +164,7 @@ export const SimulationEntitySchema = BaseEntitySchema.extend({
   has_question: z.boolean().optional(),
   // Participants — personas that REACT to this sim; each carries persona_id + user_count (both required) + their reactions.
   participants: z.array(z.object({ persona_id: z.number(), user_count: z.number().int().positive() })).default([]),
-  reactions: z.array(SimPersonaReactionEntitySchema).default([]),
+  reactions: z.array(SimulationReactionEntitySchema).default([]),
   // Driver — the single persona this sim RUNS AS (in-character; QA + survey); null = neutral.
   driver_persona_id: z.number().nullable().default(null),
   viewport: ViewportNameSchema.default('desktop'),

--- a/src/services/WidgetService.ts
+++ b/src/services/WidgetService.ts
@@ -55,7 +55,7 @@ export class WidgetService {
         widgetsData?.find((widget: WidgetData) => widget.status === 'active' && widget.type === 'widget') || null;
 
       if (matchedWidget?.settings) {
-        const widgetSettings = this.getWidgetSettings(matchedWidget);
+        const widgetSettings = this.getSettings(matchedWidget);
         if (widgetSettings) {
           const mergedSettings: WidgetSettingsData = {
             ...defaultSettings,
@@ -90,7 +90,7 @@ export class WidgetService {
     }
   }
 
-  getWidgetSettings(widget: WidgetData): WidgetSettingsData | null {
+  getSettings(widget: WidgetData): WidgetSettingsData | null {
     if (!widget?.settings) return null;
 
     const settings = widget.settings;


### PR DESCRIPTION
## What

Behavior-preserving widget-side changes for the api reaction-entity rename.

**1. Regenerated the widget SDK mirror** for the api rename of the synced Zod entity `SimPersonaReactionEntitySchema` → `SimulationReactionEntitySchema` (lives in `entities.ts`, in the widget closure). Regenerated via `sync-consumers.mjs widget` from the api worktree — only `src/sdk/contracts/entities.ts` changed. No hand-written widget code referenced the old symbol (mirror-only). Local `--check` vs the api worktree passes clean.

**2. Dropped the redundant "widget" prefix** from a `WidgetService` method: `getWidgetSettings` → `getSettings` (the sync `WidgetData`→`WidgetSettingsData` transform — "widget" is redundant on a `WidgetService` method in a widget-only repo). Updated both callers (`WidgetService.ts`, `index.tsx`). The async SDK-fetch sibling `widgetSettingsGet` is intentionally left distinct; `sdk.widgetDefaultGet` untouched.

## Verify (local)
- typecheck (`tsc --noEmit`): 0 errors
- lint (eslint `--max-warnings 0` on hand-edited files): 0 errors, 0 warnings
- build (`vite build`): PASS

## CI note
`contract-drift.yml` will be **RED** until api PR #830 merges to dev — it diffs the mirror against `api@dev`, which still has the old symbol. Expected; local `--check` vs the api worktree is green.

Do not merge until api #830 lands.