### PR TITLE
Widget cleanup: dead MessageDispatch fields + simulation->task rename + doc fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,16 +47,16 @@ npm run tag <version>    # scripts/release.sh — see Release
 Two typed oRPC procedures, both defined in `src/sdk/contracts/widget.ts`:
 
 - **`widgetStream`** — GET `/widget/stream`, output `eventIterator(WidgetEventSchema)` (SSE). Input `{ chat_id, tab_id?, marketrix_id?, marketrix_key?, application_id? }`. Server → widget.
-- **`widgetMessage`** — POST `/widget/message`, input `{ chat_id, command: WidgetCommandSchema }`, output `{ ok }`. Widget → server.
+- **`widgetMessage`** — POST `/widget/message`, input `{ chat_id, tab_id?, command: WidgetCommandSchema }`, output `{ ok }`. Widget → server.
 
 Both payloads are Zod **discriminated unions on `type`**:
 
-- `WidgetEvent` (server→widget): `registered` (`chat_id`, `application_id?`), `heartbeat`, `chat/response` (`request_id`, `text`, `task_id?`), `chat/error` (`request_id`, `error`), `task/status` (`status`, `message?`, `task_id?`, `timestamp?`), `tool/call` (`tool_call_id`, `browser_tool`, `args`, `mode?` `'show'|'do'`, `explanation?`, `state_version?`).
+- `WidgetEvent` (server→widget): `registered` (`chat_id`, `application_id?`), `heartbeat`, `chat/response` (`request_id`, `text`), `chat/delta` (`request_id`, `text` — one streamed reply fragment; deltas accumulate, the final `chat/response` full text replaces them), `chat/error` (`request_id`, `error`), `task/status` (`status`, `message?`, `task_id?`, `timestamp?`), `tool/call` (`tool_call_id`, `browser_tool`, `args`, `mode?` `'show'|'do'`, `explanation?`, `state_version?`).
 - `WidgetCommand` (widget→server): `chat/tell`, `chat/show`, `chat/do` (each `request_id` + `content`), `chat/stop` (`task_id?`), `tool/response` (`tool_call_id`, `success`, `data?`, `error?`, `state_version?`), `rrweb/metadata` (`rrweb_session_id`, …), `rrweb/events` (`rrweb_session_id`, …).
 
 **Transport** — `src/services/StreamClient.ts` is a singleton wrapping the oRPC `sdk`. It calls `sdk.widgetStream(input, { signal })` and drains the async iterator in the background. Status machine: `disconnected → connecting → connected → registered → error`. Exponential-backoff reconnect (1000 ms ×2, cap 30000 ms, **max 10 attempts**; counters reset only on a `registered` event). A `chat/error` whose `request_id === 'auth'` is **non-retriable** and permanently stops reconnection (until re-init). `heartbeat` is ignored. Sending uses `sdk.widgetMessage({ chat_id, command })`.
 
-**Round-trip** — `ChatContext.messageDispatch(content, mode)` → `apiService.messageDispatch` builds `{ type: 'chat/${mode}', request_id, content }` (mode defaults to `tell`) and fire-and-forget POSTs it; the reply arrives asynchronously over SSE as `chat/response`, matched by `request_id`. Task lifecycle arrives as `task/status`; agent browser actions arrive as `tool/call`.
+**Round-trip** — `ChatContext.messageDispatch(content, mode)` → `apiService.messageDispatch` builds `{ type: 'chat/${mode}', request_id, content }` (mode defaults to `tell`) and fire-and-forget POSTs it; the reply arrives asynchronously over SSE — streamed as `chat/delta` fragments that accumulate, then the final `chat/response` (full text) replaces them — matched by `request_id`. Task lifecycle arrives as `task/status`; agent browser actions arrive as `tool/call`.
 
 **Tool execution** — `ChatContext` handles `tool/call`: dedupe by `tool_call_id`, validate `browser_tool` against `BROWSER_TOOLS`, execute via `browserToolService.executeTool`, increment `state_version`, reply with `tool/response`. The `done` tool ends the task. `task/status` drives state: `running` activates the task (captures `task_id`); `completed`/`failed`/`stopped` clear it; `has_question` clears the pending state. `state_version` is a monotonic counter that orders tool calls.
 
@@ -87,7 +87,7 @@ Drift is enforced by `.github/workflows/contract-drift.yml` (PRs touching `src/s
 - `src/index.tsx` — public entry; all exports (see `README.md` for the customer surface).
 - `src/services/` — `StreamClient`, `RrwebSessionRecorder`, `BrowserToolService`, `ShowModeService`, `DomService`, `ChatService`, `ChatSessionManager`, `StorageService`, `ConfigManager`, `ValidationService`, `WidgetService`, `ApiService`, `ScreenShareService`.
 - `src/components/` — UI (`base/`, `blocks/`, `chat/`, `navigation/`, `ui/`, `views/`, `MarketrixWidget.tsx`). `src/design-system/` — tokens + primitives.
-- `src/context/` — `ChatContext` (one store: `{ messages, task }`), `UIStateContext`, `WidgetProviders`, `sseReducer.ts`. `src/hooks/`, `src/utils/` (incl. `bootstrap.tsx`), `src/lib/`, `src/constants/`, `src/types/`.
+- `src/context/` — `ChatContext` (one store: `{ messages, task }`), `UIStateContext`, `WidgetProviders`, `sseReducer.ts`. `src/hooks/`, `src/utils/` (incl. `bootstrap.tsx`), `src/lib/`, `src/types/`.
 - `src/test/` + colocated `*.test.ts(x)` — vitest setup, fixtures, a11y helpers.
 - `public/loader.js` — classic script-tag bootstrap. `index.html` — playground harness. `dist/` — generated only.
 

--- a/src/components/MarketrixWidget.tsx
+++ b/src/components/MarketrixWidget.tsx
@@ -137,7 +137,7 @@ export const MarketrixWidget: React.FC<MarketrixWidgetProps> = ({ config }) => {
     show_widget: config.show_widget,
     use_screenshare: config.use_screenshare,
   };
-  const showProcessingFeedback = state.isLoading || state.isSimulationRunning;
+  const showProcessingFeedback = state.isLoading || state.isTaskRunning;
   const customStyles = {
     ...semanticTokenStyles,
     '--widget-z-index': effectiveWidgetZIndex,
@@ -170,7 +170,7 @@ export const MarketrixWidget: React.FC<MarketrixWidgetProps> = ({ config }) => {
           isMinimized={state.isMinimized}
           messages={state.messages}
           currentMode={state.currentMode}
-          isSimulationRunning={state.isSimulationRunning}
+          isTaskRunning={state.isTaskRunning}
           activeView={state.activeView}
           onClose={actions.closeWidget}
           onSendMessage={actions.messageDispatch}
@@ -188,7 +188,7 @@ export const MarketrixWidget: React.FC<MarketrixWidgetProps> = ({ config }) => {
         open={state.isOpen}
         processing={state.isLoading}
         error={!!state.error}
-        taskRunning={state.isSimulationRunning}
+        taskRunning={state.isTaskRunning}
         onClick={actions.toggleWidget}
         onStop={actions.stopTask}
         accentColor={effectiveConfig.widget_accent_color}

--- a/src/components/chat/MessageContent.tsx
+++ b/src/components/chat/MessageContent.tsx
@@ -48,7 +48,7 @@ export const MessageContent: React.FC<MessageContentProps> = ({ message, isLastM
             );
           } else if (part.type === 'progress') {
             // Completed "done" shows a status icon instead of a progress line
-            if (part.browserToolName === 'done' && message.simulationStatus === 'done') {
+            if (part.browserToolName === 'done' && message.taskStatus === 'done') {
               return null;
             }
 
@@ -66,7 +66,7 @@ export const MessageContent: React.FC<MessageContentProps> = ({ message, isLastM
         })}
 
         {((message.isPlaceholder && !message.parts.some(p => p.type === 'text')) ||
-          (widgetState.isSimulationRunning && isLastMessage && (message.mode === 'show' || message.mode === 'do'))) && (
+          (widgetState.isTaskRunning && isLastMessage && (message.mode === 'show' || message.mode === 'do'))) && (
           <ThinkingIndicator isWaitingForUser={isWaitingForUser} />
         )}
       </Stack>
@@ -75,7 +75,7 @@ export const MessageContent: React.FC<MessageContentProps> = ({ message, isLastM
 
   if (
     message.isPlaceholder ||
-    (widgetState.isSimulationRunning && isLastMessage && (message.mode === 'show' || message.mode === 'do'))
+    (widgetState.isTaskRunning && isLastMessage && (message.mode === 'show' || message.mode === 'do'))
   ) {
     return <ThinkingIndicator isWaitingForUser={isWaitingForUser} />;
   }

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -10,7 +10,7 @@ import { Icon } from '../base/Icon';
 import { Stack } from '../base/Stack';
 import { Text } from '../base/Text';
 import { MessageContent } from './MessageContent';
-import { SimulationStatusIcon } from './SimulationStatusIcon';
+import { TaskStatusIcon } from './TaskStatusIcon';
 import { VideoStreamDisplay } from './VideoStreamDisplay';
 
 interface MessageItemProps {
@@ -120,9 +120,9 @@ export const MessageItem: React.FC<MessageItemProps> = ({
             </Text>
           )}
 
-          {!isUser && message.simulationStatus && (
+          {!isUser && message.taskStatus && (
             <Flex position='absolute' align='center' justify='center' style={{ bottom: '4px', right: '4px' }}>
-              <SimulationStatusIcon status={message.simulationStatus} />
+              <TaskStatusIcon status={message.taskStatus} />
             </Flex>
           )}
         </Stack>

--- a/src/components/chat/TaskStatusIcon.tsx
+++ b/src/components/chat/TaskStatusIcon.tsx
@@ -5,11 +5,11 @@ import { addOpacity } from '../../utils/color';
 import { Icon } from '../base/Icon';
 import { Spinner } from '../base/Spinner';
 
-interface SimulationStatusIconProps {
+interface TaskStatusIconProps {
   status: 'ongoing' | 'done' | 'failed' | 'stopped';
 }
 
-export const SimulationStatusIcon: React.FC<SimulationStatusIconProps> = ({ status }) => {
+export const TaskStatusIcon: React.FC<TaskStatusIconProps> = ({ status }) => {
   const { config: widgetConfig } = useWidget();
   const accentColor = widgetConfig.widget_accent_color;
   const iconSize = 14;

--- a/src/components/navigation/MessengerShell.tsx
+++ b/src/components/navigation/MessengerShell.tsx
@@ -26,7 +26,7 @@ export interface MessengerShellProps {
   isMinimized: boolean;
   messages: ChatMessage[];
   currentMode: InstructionType;
-  isSimulationRunning?: boolean;
+  isTaskRunning?: boolean;
   activeView: WidgetView;
   onClose: () => void;
   onSendMessage: (
@@ -52,7 +52,7 @@ export const MessengerShell: React.FC<MessengerShellProps> = ({
   isMinimized,
   messages,
   currentMode,
-  isSimulationRunning = false,
+  isTaskRunning = false,
   activeView,
   onClose,
   onSendMessage,
@@ -214,7 +214,7 @@ export const MessengerShell: React.FC<MessengerShellProps> = ({
                   config={config}
                   messages={messages}
                   currentMode={currentMode}
-                  isSimulationRunning={isSimulationRunning}
+                  isTaskRunning={isTaskRunning}
                   onSendMessage={onSendMessage}
                   onSetMode={onSetMode}
                   onAddMessage={onAddMessage}

--- a/src/components/views/ChatView.tsx
+++ b/src/components/views/ChatView.tsx
@@ -44,7 +44,7 @@ export interface ChatViewProps {
   config: MarketrixConfig;
   messages: ChatMessage[];
   currentMode: InstructionType;
-  isSimulationRunning?: boolean;
+  isTaskRunning?: boolean;
   onSendMessage: (
     message: string,
     mode?: InstructionType,
@@ -91,7 +91,7 @@ export const ChatView: React.FC<ChatViewProps> = ({
   config,
   messages,
   currentMode,
-  isSimulationRunning = false,
+  isTaskRunning = false,
   onSendMessage,
   onSetMode,
   onAddMessage,
@@ -210,7 +210,7 @@ export const ChatView: React.FC<ChatViewProps> = ({
           activeMode={currentMode}
           onModeChange={mode => handleModeChange(mode as InstructionType)}
           disabled={messages.some(msg => msg.isPlaceholder)}
-          taskRunning={isSimulationRunning}
+          taskRunning={isTaskRunning}
           onStop={() => {
             showModeService.cleanup();
             onStopTask?.();

--- a/src/context/ChatContext.tsx
+++ b/src/context/ChatContext.tsx
@@ -16,8 +16,8 @@ import type { UIStateActions } from './UIStateContext';
 // atomically, so messages and task can't tear across an await. UIStateContext stays separate.
 
 export interface SimulationState {
-  activeSimulationId: string | null;
-  isSimulationRunning: boolean;
+  activeTaskId: string | null;
+  isTaskRunning: boolean;
 }
 
 export interface ChatState {
@@ -40,7 +40,7 @@ export interface ChatActions {
 }
 
 export interface SimulationActions {
-  setTaskState: (payload: { activeSimulationId: string | null; isSimulationRunning: boolean }) => void;
+  setTaskState: (payload: { activeTaskId: string | null; isTaskRunning: boolean }) => void;
   stopTask: () => Promise<void>;
 }
 
@@ -53,7 +53,7 @@ interface ChatContextType {
 
 const ChatContext = createContext<ChatContextType | undefined>(undefined);
 
-const EMPTY_TASK: SimulationState = { activeSimulationId: null, isSimulationRunning: false };
+const EMPTY_TASK: SimulationState = { activeTaskId: null, isTaskRunning: false };
 
 interface ChatProviderProps {
   children: React.ReactNode;
@@ -136,10 +136,10 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
   }, [commit]);
 
   const setTaskState = useCallback(
-    (payload: { activeSimulationId: string | null; isSimulationRunning: boolean }) => {
+    (payload: { activeTaskId: string | null; isTaskRunning: boolean }) => {
       commit(s => ({
         ...s,
-        task: { activeSimulationId: payload.activeSimulationId, isSimulationRunning: payload.isSimulationRunning },
+        task: { activeTaskId: payload.activeTaskId, isTaskRunning: payload.isTaskRunning },
       }));
     },
     [commit],
@@ -150,7 +150,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
       content: string,
       mode?: InstructionType,
       applicationId?: number,
-      question?: string,
+      _question?: string,
       skipUserMessage?: boolean,
     ) => {
       const effectiveMode = mode ?? currentModeRef.current;
@@ -224,7 +224,6 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
         await apiService.messageDispatch({
           message: content,
           mode: effectiveMode,
-          question,
           requestId: placeholderId,
         });
         // Response arrives via SSE; placeholder stays "thinking"
@@ -262,7 +261,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
     if (p.apiTaskId && p.agentRunning) {
       const taskId = p.apiTaskId;
       pendingTaskRef.current = {};
-      commit(s => ({ ...s, task: { isSimulationRunning: true, activeSimulationId: taskId } }));
+      commit(s => ({ ...s, task: { isTaskRunning: true, activeTaskId: taskId } }));
     }
   }, [commit]);
 
@@ -357,7 +356,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
           return;
         }
 
-        if (!stateRef.current.task.isSimulationRunning) {
+        if (!stateRef.current.task.isTaskRunning) {
           console.log('[Widget] Tool call received before task/status running — auto-activating task');
         }
         if (event.state_version !== undefined && event.state_version > stateVersion.current) {
@@ -408,7 +407,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
   }, [previewMode, commit, maybeActivateTask, addProcessedRequestId, uiActions]);
 
   const stopTask = useCallback(async () => {
-    const taskId = stateRef.current.task.activeSimulationId ?? undefined;
+    const taskId = stateRef.current.task.activeTaskId ?? undefined;
     commit(s => reduceStop(s, currentModeRef.current));
 
     if (previewMode) return;

--- a/src/context/WidgetProviders.tsx
+++ b/src/context/WidgetProviders.tsx
@@ -19,8 +19,8 @@ const PersistBridge: React.FC<{ previewMode: boolean }> = ({ previewMode }) => {
     if (previewMode) return;
     chatService.persist({
       messages: chatState.messages,
-      isSimulationRunning: taskState.isSimulationRunning,
-      activeSimulationId: taskState.activeSimulationId,
+      isTaskRunning: taskState.isTaskRunning,
+      activeTaskId: taskState.activeTaskId,
       currentMode: uiState.currentMode,
       isOpen: uiState.isOpen,
       isMinimized: uiState.isMinimized,
@@ -29,8 +29,8 @@ const PersistBridge: React.FC<{ previewMode: boolean }> = ({ previewMode }) => {
   }, [
     previewMode,
     chatState.messages,
-    taskState.isSimulationRunning,
-    taskState.activeSimulationId,
+    taskState.isTaskRunning,
+    taskState.activeTaskId,
     uiState.currentMode,
     uiState.isOpen,
     uiState.isMinimized,
@@ -72,8 +72,8 @@ const InitBridge: React.FC<{ children: React.ReactNode; previewMode: boolean }> 
 
       chatActions.setMessages(snapshot.messages);
       taskActions.setTaskState({
-        activeSimulationId: snapshot.isSimulationRunning ? snapshot.activeSimulationId : null,
-        isSimulationRunning: snapshot.isSimulationRunning,
+        activeTaskId: snapshot.isTaskRunning ? snapshot.activeTaskId : null,
+        isTaskRunning: snapshot.isTaskRunning,
       });
 
       if (chatId) {

--- a/src/context/__tests__/sseReducer.test.ts
+++ b/src/context/__tests__/sseReducer.test.ts
@@ -24,12 +24,12 @@ const agentMessage = (overrides: Partial<ChatMessage> = {}): ChatMessage => ({
 
 const runningState = (overrides: Partial<ChatMessage> = {}): SseState => ({
   messages: [agentMessage(overrides)],
-  task: { activeSimulationId: 'task-1', isSimulationRunning: true },
+  task: { activeTaskId: 'task-1', isTaskRunning: true },
 });
 
 const idleState = (): SseState => ({
   messages: [agentMessage({ placeholderState: undefined })],
-  task: { activeSimulationId: null, isSimulationRunning: false },
+  task: { activeTaskId: null, isTaskRunning: false },
 });
 
 // task/status
@@ -53,20 +53,20 @@ describe('reduceSse — task/status', () => {
 
   it('completed ends the task and marks the active message done', () => {
     const result = reduceSse(runningState(), { type: 'task/status', status: 'completed' }, 'do');
-    expect(result.state.task).toEqual({ isSimulationRunning: false, activeSimulationId: null });
-    expect(result.state.messages[0].simulationStatus).toBe('done');
+    expect(result.state.task).toEqual({ isTaskRunning: false, activeTaskId: null });
+    expect(result.state.messages[0].taskStatus).toBe('done');
   });
 
   it('failed ends the task and marks the active message failed', () => {
     const result = reduceSse(runningState(), { type: 'task/status', status: 'failed' }, 'do');
-    expect(result.state.task.isSimulationRunning).toBe(false);
-    expect(result.state.messages[0].simulationStatus).toBe('failed');
+    expect(result.state.task.isTaskRunning).toBe(false);
+    expect(result.state.messages[0].taskStatus).toBe('failed');
   });
 
   it('stopped ends the task and marks the active message stopped', () => {
     const result = reduceSse(runningState(), { type: 'task/status', status: 'stopped' }, 'do');
-    expect(result.state.task.isSimulationRunning).toBe(false);
-    expect(result.state.messages[0].simulationStatus).toBe('stopped');
+    expect(result.state.task.isTaskRunning).toBe(false);
+    expect(result.state.messages[0].taskStatus).toBe('stopped');
   });
 
   it('terminal status overwrites content when the event carries a message', () => {
@@ -75,7 +75,7 @@ describe('reduceSse — task/status', () => {
     expect(result.state.messages[0].content).toBe('All done!');
   });
 
-  it('has_question pauses (not terminal): clears spinner, flips to waiting-for-user, no simulationStatus', () => {
+  it('has_question pauses (not terminal): clears spinner, flips to waiting-for-user, no taskStatus', () => {
     const before = runningState();
     expect(hasThinkingMarker(before.messages[0].content)).toBe(true);
 
@@ -87,8 +87,8 @@ describe('reduceSse — task/status', () => {
     expect(msg.placeholderState).toBe('waiting-for-user');
     expect(msg.content).toContain('Which account?');
     // Paused, not finished — no terminal icon.
-    expect(msg.simulationStatus).toBeUndefined();
-    expect(result.state.task).toEqual({ isSimulationRunning: false, activeSimulationId: null });
+    expect(msg.taskStatus).toBeUndefined();
+    expect(result.state.task).toEqual({ isTaskRunning: false, activeTaskId: null });
   });
 });
 
@@ -121,7 +121,7 @@ describe('reduceSse — tool/call', () => {
 
   it('auto-activates the task when a tool arrives before task/status running', () => {
     const result = reduceSse(idleState(), toolCall(), 'do');
-    expect(result.state.task.isSimulationRunning).toBe(true);
+    expect(result.state.task.isTaskRunning).toBe(true);
   });
 
   it('adds an in-progress progress line to the active message', () => {
@@ -145,7 +145,7 @@ describe('reduceSse — chat/response', () => {
   it('resolves the matching placeholder and turns off loading', () => {
     const state: SseState = {
       messages: [agentMessage({ id: 'req-1', content: '\n\n__THINKING__', parts: [] })],
-      task: { activeSimulationId: null, isSimulationRunning: false },
+      task: { activeTaskId: null, isTaskRunning: false },
     };
     const event: WidgetEvent = { type: 'chat/response', request_id: 'req-1', text: 'Here you go' };
     const result = reduceSse(state, event, 'tell');
@@ -163,7 +163,7 @@ describe('reduceSse — chat/delta', () => {
   it('accumulates fragments into one streaming part and clears the placeholder', () => {
     const state: SseState = {
       messages: [agentMessage({ id: 'req-1', content: '\n\n__THINKING__', parts: [] })],
-      task: { activeSimulationId: null, isSimulationRunning: false },
+      task: { activeTaskId: null, isTaskRunning: false },
     };
     const first = reduceSse(state, { type: 'chat/delta', request_id: 'req-1', text: 'Hel' }, 'tell');
     const second = reduceSse(first.state, { type: 'chat/delta', request_id: 'req-1', text: 'lo' }, 'tell');
@@ -179,7 +179,7 @@ describe('reduceSse — chat/delta', () => {
   it('final chat/response replaces the streamed part (no duplication)', () => {
     const state: SseState = {
       messages: [agentMessage({ id: 'req-1', content: '\n\n__THINKING__', parts: [] })],
-      task: { activeSimulationId: null, isSimulationRunning: false },
+      task: { activeTaskId: null, isTaskRunning: false },
     };
     const streamed = reduceSse(state, { type: 'chat/delta', request_id: 'req-1', text: 'Hello wor' }, 'tell');
     const final = reduceSse(
@@ -199,7 +199,7 @@ describe('reduceSse — chat/error', () => {
   it('writes an error message into the matching placeholder and turns off loading', () => {
     const state: SseState = {
       messages: [agentMessage({ id: 'req-2' })],
-      task: { activeSimulationId: null, isSimulationRunning: false },
+      task: { activeTaskId: null, isTaskRunning: false },
     };
     const event: WidgetEvent = { type: 'chat/error', request_id: 'req-2', error: 'boom' };
     const result = reduceSse(state, event, 'tell');
@@ -271,11 +271,11 @@ describe('reduceToolProgress / reduceToolDone / reduceStop', () => {
           ],
         }),
       ],
-      task: { activeSimulationId: 'task-1', isSimulationRunning: true },
+      task: { activeTaskId: 'task-1', isTaskRunning: true },
     };
     const result = reduceToolDone(withDoneLine, 'do');
-    expect(result.task).toEqual({ isSimulationRunning: false, activeSimulationId: null });
-    expect(result.messages[0].simulationStatus).toBe('done');
+    expect(result.task).toEqual({ isTaskRunning: false, activeTaskId: null });
+    expect(result.messages[0].taskStatus).toBe('done');
     expect((result.messages[0].parts ?? []).some(p => p.type === 'progress' && p.browserToolName === 'done')).toBe(
       false,
     );
@@ -283,7 +283,7 @@ describe('reduceToolProgress / reduceToolDone / reduceStop', () => {
 
   it('reduceStop marks the active message stopped and ends the task', () => {
     const result = reduceStop(runningState(), 'do');
-    expect(result.messages[0].simulationStatus).toBe('stopped');
-    expect(result.task).toEqual({ isSimulationRunning: false, activeSimulationId: null });
+    expect(result.messages[0].taskStatus).toBe('stopped');
+    expect(result.task).toEqual({ isTaskRunning: false, activeTaskId: null });
   });
 });

--- a/src/context/sseReducer.ts
+++ b/src/context/sseReducer.ts
@@ -13,8 +13,8 @@ import {
 } from '../utils/chat';
 
 export interface SseSimulationState {
-  activeSimulationId: string | null;
-  isSimulationRunning: boolean;
+  activeTaskId: string | null;
+  isTaskRunning: boolean;
 }
 
 export interface SseState {
@@ -45,7 +45,7 @@ type ProgressStatus = 'in_progress' | 'completed' | 'failed';
 
 function applyProgress(
   messages: ChatMessage[],
-  isSimulationRunning: boolean,
+  isTaskRunning: boolean,
   currentMode: InstructionType,
   browserToolName: string,
   explanation: string,
@@ -55,14 +55,14 @@ function applyProgress(
   const friendlyName = getFriendlyToolName(browserToolName);
   const found = findMessageForProgress({
     messages,
-    isSimulationRunning,
+    isTaskRunning,
     currentMode,
     requireContent: status === 'failed',
   });
   if (!found) return messages;
 
   let updatedMsg = found.message;
-  const shouldWait = isSimulationRunning && currentMode === 'show' && WAIT_FOR_USER_TOOLS.has(browserToolName);
+  const shouldWait = isTaskRunning && currentMode === 'show' && WAIT_FOR_USER_TOOLS.has(browserToolName);
   const isDoneTool = browserToolName === 'done';
   const isShowOrDo = currentMode === 'show' || currentMode === 'do';
 
@@ -70,20 +70,20 @@ function applyProgress(
     if (!isDoneTool) {
       updatedMsg = addProgressLine(updatedMsg, friendlyName, explanation || friendlyName);
     }
-    if (isSimulationRunning && isShowOrDo) {
-      updatedMsg = updateThinkingMarker(updatedMsg, isSimulationRunning, currentMode, shouldWait);
+    if (isTaskRunning && isShowOrDo) {
+      updatedMsg = updateThinkingMarker(updatedMsg, isTaskRunning, currentMode, shouldWait);
     }
   } else if (status === 'completed') {
     if (!isDoneTool) {
       updatedMsg = markProgressLineComplete(updatedMsg);
     }
-    if (isSimulationRunning && isShowOrDo) {
-      updatedMsg = updateThinkingMarker(updatedMsg, isSimulationRunning, currentMode, false);
+    if (isTaskRunning && isShowOrDo) {
+      updatedMsg = updateThinkingMarker(updatedMsg, isTaskRunning, currentMode, false);
     }
   } else {
     updatedMsg = markProgressLineFailed(updatedMsg, friendlyName, error || '');
-    if (isSimulationRunning && isShowOrDo) {
-      updatedMsg = updateThinkingMarker(updatedMsg, isSimulationRunning, currentMode, false);
+    if (isTaskRunning && isShowOrDo) {
+      updatedMsg = updateThinkingMarker(updatedMsg, isTaskRunning, currentMode, false);
     }
   }
 
@@ -104,7 +104,7 @@ export function reduceToolProgress(
     ...state,
     messages: applyProgress(
       state.messages,
-      state.task.isSimulationRunning,
+      state.task.isTaskRunning,
       currentMode,
       browserToolName,
       explanation,
@@ -118,7 +118,7 @@ export function reduceToolProgress(
 export function reduceToolDone(state: SseState, currentMode: InstructionType): SseState {
   const found = findMessageForProgress({
     messages: state.messages,
-    isSimulationRunning: state.task.isSimulationRunning,
+    isTaskRunning: state.task.isTaskRunning,
     currentMode,
     requireContent: false,
   });
@@ -127,24 +127,24 @@ export function reduceToolDone(state: SseState, currentMode: InstructionType): S
     const updatedParts = (found.message.parts ?? []).filter(
       part => !(part.type === 'progress' && part.browserToolName === 'done'),
     );
-    messages[found.index] = { ...found.message, simulationStatus: 'done', parts: updatedParts };
+    messages[found.index] = { ...found.message, taskStatus: 'done', parts: updatedParts };
   }
-  return { messages, task: { isSimulationRunning: false, activeSimulationId: null } };
+  return { messages, task: { isTaskRunning: false, activeTaskId: null } };
 }
 
 // User-initiated stop — flag the active message `stopped` and end the task.
 export function reduceStop(state: SseState, currentMode: InstructionType): SseState {
   const found = findMessageForProgress({
     messages: state.messages,
-    isSimulationRunning: state.task.isSimulationRunning,
+    isTaskRunning: state.task.isTaskRunning,
     currentMode,
     requireContent: false,
   });
   const messages = [...state.messages];
   if (found) {
-    messages[found.index] = { ...found.message, simulationStatus: 'stopped' };
+    messages[found.index] = { ...found.message, taskStatus: 'stopped' };
   }
-  return { messages, task: { isSimulationRunning: false, activeSimulationId: null } };
+  return { messages, task: { isTaskRunning: false, activeTaskId: null } };
 }
 
 // Returns next state + effects. Unknown / non-stateful events (registered, heartbeat) are ignored.
@@ -152,13 +152,13 @@ export function reduceSse(state: SseState, event: WidgetEvent, currentMode: Inst
   switch (event.type) {
     case 'tool/call': {
       // Auto-activate the task if a tool arrives before `task/status running`.
-      const task = state.task.isSimulationRunning ? state.task : { ...state.task, isSimulationRunning: true };
-      const isSimulationRunning = task.isSimulationRunning;
+      const task = state.task.isTaskRunning ? state.task : { ...state.task, isTaskRunning: true };
+      const isTaskRunning = task.isTaskRunning;
       const mode = event.mode || currentMode || 'do';
       const explanation = event.explanation || '';
       const messages = applyProgress(
         state.messages,
-        isSimulationRunning,
+        isTaskRunning,
         currentMode,
         event.browser_tool,
         explanation,
@@ -189,7 +189,7 @@ export function reduceSse(state: SseState, event: WidgetEvent, currentMode: Inst
         // Paused awaiting a user answer — not terminal. Stop spinner, flip to "waiting for you".
         const found = findMessageForProgress({
           messages: state.messages,
-          isSimulationRunning: state.task.isSimulationRunning,
+          isTaskRunning: state.task.isTaskRunning,
           currentMode,
           requireContent: false,
         });
@@ -202,27 +202,27 @@ export function reduceSse(state: SseState, event: WidgetEvent, currentMode: Inst
             ...(statusMessage && { content: statusMessage }),
           };
         }
-        return { state: { messages, task: { isSimulationRunning: false, activeSimulationId: null } }, effects: [] };
+        return { state: { messages, task: { isTaskRunning: false, activeTaskId: null } }, effects: [] };
       }
       // completed | failed | stopped — terminal.
       const found = findMessageForProgress({
         messages: state.messages,
-        isSimulationRunning: state.task.isSimulationRunning,
+        isTaskRunning: state.task.isTaskRunning,
         currentMode,
         requireContent: false,
       });
       const messages = [...state.messages];
       if (found) {
-        let simulationStatus: 'done' | 'failed' | 'stopped' = 'done';
-        if (event.status === 'failed') simulationStatus = 'failed';
-        else if (event.status === 'stopped') simulationStatus = 'stopped';
+        let taskStatus: 'done' | 'failed' | 'stopped' = 'done';
+        if (event.status === 'failed') taskStatus = 'failed';
+        else if (event.status === 'stopped') taskStatus = 'stopped';
         messages[found.index] = {
           ...found.message,
-          simulationStatus,
+          taskStatus,
           ...(statusMessage && { content: statusMessage }),
         };
       }
-      return { state: { messages, task: { isSimulationRunning: false, activeSimulationId: null } }, effects: [] };
+      return { state: { messages, task: { isTaskRunning: false, activeTaskId: null } }, effects: [] };
     }
 
     case 'chat/delta': {

--- a/src/hooks/useWidget.ts
+++ b/src/hooks/useWidget.ts
@@ -33,7 +33,7 @@ interface UseWidgetActions {
   setAgentAvailable: (available: boolean) => void;
   setError: (error: string | undefined) => void;
   clearError: () => void;
-  setTaskState: (payload: { activeSimulationId: string | null; isSimulationRunning: boolean }) => void;
+  setTaskState: (payload: { activeTaskId: string | null; isTaskRunning: boolean }) => void;
   addMessage: (message: ChatMessage) => void;
   updateMessage: (messageId: string, updates: Partial<ChatMessage>) => void;
   removeMessage: (messageId: string) => void;
@@ -64,15 +64,15 @@ export const useWidget = ({ config }: UseWidgetProps = {}) => {
       error: uiState.error,
       activeView: uiState.activeView,
       messages: chatState.messages,
-      activeSimulationId: taskState.activeSimulationId,
-      isSimulationRunning: taskState.isSimulationRunning,
+      activeTaskId: taskState.activeTaskId,
+      isTaskRunning: taskState.isTaskRunning,
     }),
     [uiState, chatState, taskState],
   );
 
   const resetChat = useCallback(() => {
     chatActions.clearMessages();
-    taskActions.setTaskState({ activeSimulationId: null, isSimulationRunning: false });
+    taskActions.setTaskState({ activeTaskId: null, isTaskRunning: false });
     uiActions.setError(undefined);
   }, [chatActions, taskActions, uiActions]);
 

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -1,5 +1,5 @@
 import { sdk, type WidgetCommand } from '../sdk';
-import type { MarketrixConfig, MessageDispatchRequest, MessageDispatchResponse } from '../types';
+import type { MarketrixConfig, MessageDispatchRequest } from '../types';
 import { chatSessionManager } from './ChatSessionManager';
 import { StreamClient } from './StreamClient';
 
@@ -85,7 +85,7 @@ export class ApiService {
   }
 
   /** Fire-and-forget send over the typed stream; the reply arrives asynchronously as a chat/response event. */
-  async messageDispatch(request: MessageDispatchRequest): Promise<MessageDispatchResponse> {
+  async messageDispatch(request: MessageDispatchRequest): Promise<void> {
     const chatId = await chatSessionManager.getOrCreateChatId();
     if (!chatId) throw new Error('Failed to initialize chat session');
 
@@ -108,13 +108,6 @@ export class ApiService {
 
     const wsClient = StreamClient.getInstance();
     wsClient.send(command);
-
-    return {
-      messageId: requestId,
-      response: '', // populated later by the chat/response stream event
-      mode,
-      timestamp: new Date(),
-    };
   }
 
   updateConfig(newConfig: Partial<MarketrixConfig>): void {

--- a/src/services/ChatService.ts
+++ b/src/services/ChatService.ts
@@ -5,8 +5,8 @@ import { storageService } from './StorageService';
 /** Widget state persisted to / restored from localStorage; React context is the runtime source of truth. */
 export interface ChatSnapshot {
   messages: ChatMessage[];
-  isSimulationRunning: boolean;
-  activeSimulationId: string | null;
+  isTaskRunning: boolean;
+  activeTaskId: string | null;
   currentMode: InstructionType;
   isOpen: boolean;
   isMinimized: boolean;
@@ -41,8 +41,8 @@ export class ChatService {
       storageService.updateContext({
         chat_id: chatId,
         messages: [],
-        isSimulationRunning: false,
-        activeSimulationId: null,
+        isTaskRunning: false,
+        activeTaskId: null,
         currentMode: 'tell',
         isOpen: false,
         isMinimized: false,
@@ -81,7 +81,7 @@ export class ChatService {
             timestamp: new Date(msg.timestamp),
             videoStream: undefined,
             placeholderState: msg.placeholderState,
-            simulationStatus: msg.simulationStatus,
+            taskStatus: msg.taskStatus,
             parts: msg.parts || [],
           };
 
@@ -98,8 +98,8 @@ export class ChatService {
 
     return {
       messages,
-      isSimulationRunning: context.isSimulationRunning,
-      activeSimulationId: context.activeSimulationId,
+      isTaskRunning: context.isTaskRunning,
+      activeTaskId: context.activeTaskId,
       currentMode: context.currentMode,
       isOpen: context.isOpen,
       isMinimized: context.isMinimized,
@@ -133,15 +133,15 @@ export class ChatService {
           isSystemMessage: msg.isSystemMessage,
           isPlaceholder: msg.isPlaceholder,
           placeholderState: msg.placeholderState,
-          simulationStatus: msg.simulationStatus,
+          taskStatus: msg.taskStatus,
           parts: msg.parts,
         }));
 
       storageService.updateContext({
         chat_id: this.chatId,
         messages: serializedMessages,
-        isSimulationRunning: snapshot.isSimulationRunning,
-        activeSimulationId: snapshot.activeSimulationId,
+        isTaskRunning: snapshot.isTaskRunning,
+        activeTaskId: snapshot.activeTaskId,
         currentMode: snapshot.currentMode,
         isOpen: snapshot.isOpen,
         isMinimized: snapshot.isMinimized,

--- a/src/services/StorageService.ts
+++ b/src/services/StorageService.ts
@@ -18,8 +18,8 @@ export interface MarketrixChatContext {
   chat_id: string | null;
 
   messages: StoredMessage[];
-  isSimulationRunning: boolean;
-  activeSimulationId: string | null;
+  isTaskRunning: boolean;
+  activeTaskId: string | null;
   currentMode: InstructionType;
   isOpen: boolean;
   isMinimized: boolean;
@@ -33,8 +33,8 @@ export interface MarketrixChatContext {
 const DEFAULT_CONTEXT: MarketrixChatContext = {
   chat_id: null,
   messages: [],
-  isSimulationRunning: false,
-  activeSimulationId: null,
+  isTaskRunning: false,
+  activeTaskId: null,
   currentMode: 'tell',
   isOpen: false,
   isMinimized: false,
@@ -155,12 +155,12 @@ class StorageService {
 
   getChatState(): Pick<
     MarketrixChatContext,
-    'isSimulationRunning' | 'activeSimulationId' | 'currentMode' | 'isOpen' | 'isMinimized' | 'isLoading'
+    'isTaskRunning' | 'activeTaskId' | 'currentMode' | 'isOpen' | 'isMinimized' | 'isLoading'
   > {
     const ctx = this.getContext();
     return {
-      isSimulationRunning: ctx.isSimulationRunning,
-      activeSimulationId: ctx.activeSimulationId,
+      isTaskRunning: ctx.isTaskRunning,
+      activeTaskId: ctx.activeTaskId,
       currentMode: ctx.currentMode,
       isOpen: ctx.isOpen,
       isMinimized: ctx.isMinimized,
@@ -172,7 +172,7 @@ class StorageService {
     state: Partial<
       Pick<
         MarketrixChatContext,
-        'isSimulationRunning' | 'activeSimulationId' | 'currentMode' | 'isOpen' | 'isMinimized' | 'isLoading'
+        'isTaskRunning' | 'activeTaskId' | 'currentMode' | 'isOpen' | 'isMinimized' | 'isLoading'
       >
     >,
   ): void {

--- a/src/services/__tests__/sse-event-handling.test.ts
+++ b/src/services/__tests__/sse-event-handling.test.ts
@@ -158,7 +158,7 @@ describe('SSE event discriminated-union contract (WidgetEventSchema)', () => {
 
   describe('task/status "has_question" pauses the active message (clears running spinner)', () => {
     // Mirrors the ChatContext `has_question` reducer: strip the thinking marker (stops the spinner)
-    // and flip to "waiting-for-user" without setting a terminal simulationStatus icon.
+    // and flip to "waiting-for-user" without setting a terminal taskStatus icon.
     const applyHasQuestionTransition = (message: ChatMessage, statusMessage?: string): ChatMessage => {
       const cleared = updateThinkingMarker(message, false, 'do');
       return {
@@ -175,7 +175,7 @@ describe('SSE event discriminated-union contract (WidgetEventSchema)', () => {
       timestamp: new Date(),
       mode: 'do',
       placeholderState: 'thinking',
-      simulationStatus: 'ongoing',
+      taskStatus: 'ongoing',
     });
 
     it('"has_question" is a valid SSE event that carries an optional message', () => {
@@ -195,9 +195,9 @@ describe('SSE event discriminated-union contract (WidgetEventSchema)', () => {
       const after = applyHasQuestionTransition(runningMessage());
       expect(after.placeholderState).toBe('waiting-for-user');
       // Terminal icon statuses must NOT be applied — the task is paused, not finished.
-      expect(after.simulationStatus).not.toBe('done');
-      expect(after.simulationStatus).not.toBe('failed');
-      expect(after.simulationStatus).not.toBe('stopped');
+      expect(after.taskStatus).not.toBe('done');
+      expect(after.taskStatus).not.toBe('failed');
+      expect(after.taskStatus).not.toBe('stopped');
     });
 
     it('surfaces the question text when the event includes a message', () => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -47,7 +47,7 @@ export interface ChatMessage {
   isPlaceholder?: boolean;
   placeholderState?: 'thinking' | 'waiting-for-user';
   parts?: MessagePart[];
-  simulationStatus?: 'ongoing' | 'done' | 'failed' | 'stopped';
+  taskStatus?: 'ongoing' | 'done' | 'failed' | 'stopped';
 }
 
 export interface MessagePart {
@@ -72,27 +72,15 @@ export interface WidgetState {
   currentMode: InstructionType;
   agentAvailable: boolean;
   error?: string;
-  activeSimulationId: string | null;
-  isSimulationRunning: boolean;
+  activeTaskId: string | null;
+  isTaskRunning: boolean;
   activeView: WidgetView;
 }
 
 export interface MessageDispatchRequest {
   message?: string;
   mode?: InstructionType;
-  mtxId?: string;
-  mtxKey?: string;
-  application_id?: number;
-  question?: string;
   requestId?: string;
-}
-
-export interface MessageDispatchResponse {
-  messageId: string;
-  response: string;
-  mode: InstructionType;
-  timestamp: Date;
-  task_id?: string;
 }
 
 export type WidgetPosition = WidgetSettingsData['widget_position'];

--- a/src/utils/chat.ts
+++ b/src/utils/chat.ts
@@ -30,14 +30,14 @@ function findTaskMessageIndex(messages: ChatMessage[]): number {
 
 export interface FindMessageOptions {
   messages: ChatMessage[];
-  isSimulationRunning: boolean;
+  isTaskRunning: boolean;
   currentMode: InstructionType;
   requireContent?: boolean;
 }
 
 function matchesProgressCriteria(
   msg: ChatMessage,
-  isSimulationRunning: boolean,
+  isTaskRunning: boolean,
   currentMode: InstructionType,
   requireContent: boolean | undefined,
   checkMode: boolean,
@@ -48,7 +48,7 @@ function matchesProgressCriteria(
 
   // Active show/do: require mode match, but stay lenient on placeholders whose mode is still
   // undefined — tool calls can race ahead of the mode being set.
-  if (checkMode && isSimulationRunning && (currentMode === 'show' || currentMode === 'do')) {
+  if (checkMode && isTaskRunning && (currentMode === 'show' || currentMode === 'do')) {
     if (msg.isPlaceholder) {
       if (msg.mode !== undefined && msg.mode !== currentMode) {
         return false;
@@ -79,16 +79,16 @@ export function findMessageForProgress(options: FindMessageOptions): {
   index: number;
   message: ChatMessage;
 } | null {
-  const { messages, isSimulationRunning, currentMode, requireContent } = options;
+  const { messages, isTaskRunning, currentMode, requireContent } = options;
   let taskMessageIndex = -1;
 
-  if (isSimulationRunning && (currentMode === 'show' || currentMode === 'do')) {
+  if (isTaskRunning && (currentMode === 'show' || currentMode === 'do')) {
     const checkMode = true;
 
     // Priority 1: last placeholder with content in matching mode.
     for (let i = messages.length - 1; i >= 0; i--) {
       const msg = messages[i];
-      const matchesCriteria = matchesProgressCriteria(msg, isSimulationRunning, currentMode, requireContent, checkMode);
+      const matchesCriteria = matchesProgressCriteria(msg, isTaskRunning, currentMode, requireContent, checkMode);
       const isPlaceholder = msg.isPlaceholder;
       const hasContent = !requireContent || msg.content.trim().length > 0 || (msg.parts && msg.parts.length > 0);
 
@@ -102,13 +102,7 @@ export function findMessageForProgress(options: FindMessageOptions): {
     if (taskMessageIndex < 0 && !requireContent) {
       for (let i = messages.length - 1; i >= 0; i--) {
         const msg = messages[i];
-        const matchesCriteria = matchesProgressCriteria(
-          msg,
-          isSimulationRunning,
-          currentMode,
-          requireContent,
-          checkMode,
-        );
+        const matchesCriteria = matchesProgressCriteria(msg, isTaskRunning, currentMode, requireContent, checkMode);
         const isPlaceholder = msg.isPlaceholder;
 
         if (matchesCriteria && isPlaceholder) {
@@ -122,13 +116,7 @@ export function findMessageForProgress(options: FindMessageOptions): {
     if (taskMessageIndex < 0) {
       for (let i = messages.length - 1; i >= 0; i--) {
         const msg = messages[i];
-        const matchesCriteria = matchesProgressCriteria(
-          msg,
-          isSimulationRunning,
-          currentMode,
-          requireContent,
-          checkMode,
-        );
+        const matchesCriteria = matchesProgressCriteria(msg, isTaskRunning, currentMode, requireContent, checkMode);
         const isPlaceholder = msg.isPlaceholder;
 
         if (matchesCriteria && !isPlaceholder) {
@@ -140,7 +128,7 @@ export function findMessageForProgress(options: FindMessageOptions): {
   }
 
   // Fallback (no active task or no match) — critical: tool calls can arrive before
-  // isSimulationRunning flips true.
+  // isTaskRunning flips true.
   if (taskMessageIndex < 0) {
     // Priority 1: last placeholder message, no mode/content requirement.
     for (let i = messages.length - 1; i >= 0; i--) {
@@ -194,7 +182,7 @@ export function findMessageForProgress(options: FindMessageOptions): {
 
   console.warn('[MessageFinder] No message found for progress update', {
     totalMessages: messages.length,
-    isSimulationRunning,
+    isTaskRunning,
     currentMode,
   });
   return null;
@@ -355,13 +343,13 @@ export function markProgressLineFailed(message: ChatMessage, browserToolName: st
 
 export function updateThinkingMarker(
   message: ChatMessage,
-  isSimulationRunning: boolean,
+  isTaskRunning: boolean,
   currentMode: 'show' | 'tell' | 'do',
   isWaitingForUser: boolean = false,
 ): ChatMessage {
   const msg = ensureMessageStructure(message);
 
-  if (!isSimulationRunning || (currentMode !== 'show' && currentMode !== 'do')) {
+  if (!isTaskRunning || (currentMode !== 'show' && currentMode !== 'do')) {
     if (hasThinkingMarker(msg.content)) {
       return {
         ...msg,


### PR DESCRIPTION
Behavior-preserving cleanups + an internal terminology rename. No proto/SDK-mirror change (no edits to `src/sdk/*`).

## Changes

1. **Drop dead `MessageDispatchRequest` fields.** `mtxId/mtxKey/application_id/question` were declared but never read by the only consumer (`ApiService.messageDispatch` reads only `message/mode/requestId`). Removed from the interface; removed the now-dead `question` property from the ChatContext call. The ChatContext `messageDispatch` positional param stays (its callers still pass it positionally as the pre-existing, already-vestigial 4th arg) — marked `_question` since it's ignored.

2. **`messageDispatch` returns `Promise<void>`.** It built and returned a `MessageDispatchResponse` with a hardcoded `response: ''` that the sole caller discarded — the real reply arrives over SSE as `chat/response`. Deleted the return object, the `MessageDispatchResponse` type, and its import. (The wrapping `ChatContext`/`useWidget` methods were already `Promise<void>`.)

3. **Rename `simulation*` -> `task*`** to match the canonical vocabulary in `CLAUDE.md` (the widget has no "simulation" concept):
   - `ChatMessage.simulationStatus` -> `taskStatus`
   - `WidgetState.activeSimulationId` -> `activeTaskId`, `WidgetState.isSimulationRunning` -> `isTaskRunning`
   - component + file `SimulationStatusIcon` -> `TaskStatusIcon` (`git mv`)
   - fanned out across `sseReducer`, `ChatContext`, `WidgetProviders`, `useWidget`, `ChatService`, `StorageService`, `MarketrixWidget`, `ChatView`, `MessengerShell`, `MessageItem`, `MessageContent`, `chat.ts` utils + tests.
   - The persisted localStorage keys change but read `undefined`/falsy on old data and self-heal (accepted, behavior-preserving).

4. **CLAUDE.md doc fixes** (verified against `src/sdk/contracts/widget.ts` + `sseReducer.ts`):
   - `chat/response` carries only `request_id`/`text` — removed the bogus `task_id?`.
   - Documented the streaming `chat/delta` event (fragments accumulate; final `chat/response` replaces them), incl. the round-trip prose.
   - Added the missing `tab_id?` to the `widgetMessage` input shape.
   - Removed the non-existent `src/constants/` from the structure list.

## Verification

- `type-check` (tsc): 0 errors
- `lint`/`format:check`: 0 errors (1 pre-existing non-null-assertion **warning** in untouched `sseReducer.ts:238`, under CI's 200-warning gate)
- `build` (vite): PASS
- `test:run` (vitest): 218 passed / 18 files
- Grep confirms `simulationStatus` / `activeSimulationId` / `isSimulationRunning` / `SimulationStatusIcon` and `MessageDispatchResponse` are gone from `src`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbcPkX948hrUvTy9u4z2uS