### PR TITLE
Widget Wave-B: drop dead tool/call event state_version read + mirror regen

### DIFF
--- a/src/context/ChatContext.tsx
+++ b/src/context/ChatContext.tsx
@@ -359,9 +359,6 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
         if (!stateRef.current.task.isTaskRunning) {
           console.log('[Widget] Tool call received before task/status running — auto-activating task');
         }
-        if (event.state_version !== undefined && event.state_version > stateVersion.current) {
-          stateVersion.current = event.state_version;
-        }
       } else if (
         event.type === 'task/status' &&
         (event.status === 'completed' || event.status === 'failed' || event.status === 'stopped')

--- a/src/sdk/contracts/widget.ts
+++ b/src/sdk/contracts/widget.ts
@@ -57,7 +57,6 @@ export const WidgetEventSchema = z.discriminatedUnion('type', [
     args: z.record(z.string(), z.unknown()),
     mode: z.enum(['show', 'do']).optional(),
     explanation: z.string().optional(),
-    state_version: z.number().optional(),
   }),
 ]);
 export type WidgetEvent = z.infer<typeof WidgetEventSchema>;


### PR DESCRIPTION
## What

- **Mirror regen** (`src/sdk/contracts/widget.ts`): re-ran `sync-consumers.mjs widget` against the api Wave-B worktree. This removes `state_version` from the **tool/call EVENT** (server→widget). The `state_version` field on the **tool/response COMMAND** (widget→server) is unchanged and stays on the wire.
- **Dead-code removal** (`src/context/ChatContext.tsx`): removed the incoming-event dedup block that read `event.state_version` on a `tool/call`. The tool/call event no longer carries `state_version`, and it was always `0`, so this branch never fired — behavior-preserving.
- **Kept**: the widget's own local `stateVersion` counter (`useRef(0)`), its `stateVersion.current++` increments, and the command-side `state_version: stateVersion.current` sends that populate the retained tool/response command field.

## Verify (local, repo scripts)

- typecheck (`tsc --noEmit`): 0 errors
- lint (`eslint src/context/ChatContext.tsx --max-warnings 0`): 0 errors (the regenerated `src/sdk/*` is eslint-ignored as generated)
- build (`vite build`): PASS
- tests (`vitest run`): 218 passed / 18 files
- local `--check` vs the api Wave-B worktree: CLEAN (exit 0)

## CI note

`contract-drift.yml` will be **red until api PR #835 merges to dev** (the workflow sparse-checkouts `api@dev`, which still carries the old event field). Expected — local `--check` against the api Wave-B worktree passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbcPkX948hrUvTy9u4z2uS