### PR TITLE
[Refactor] - Remove non-null assertion when resolving streamed content in SSE reducer

### DIFF
--- a/src/context/sseReducer.ts
+++ b/src/context/sseReducer.ts
@@ -230,12 +230,14 @@ export function reduceSse(state: SseState, event: WidgetEvent, currentMode: Inst
         if (msg.id !== event.request_id) return msg;
         const parts = [...(msg.parts ?? [])];
         const last = parts[parts.length - 1];
+        let streamed: string;
         if (last?.type === 'text' && last.streaming) {
-          parts[parts.length - 1] = { ...last, content: last.content + event.text };
+          streamed = last.content + event.text;
+          parts[parts.length - 1] = { ...last, content: streamed };
         } else {
-          parts.push({ type: 'text' as const, content: event.text, streaming: true });
+          streamed = event.text;
+          parts.push({ type: 'text' as const, content: streamed, streaming: true });
         }
-        const streamed = parts[parts.length - 1]!.content;
         return { ...msg, content: streamed, isPlaceholder: false, placeholderState: undefined, parts };
       });
       return { state: { ...state, messages }, effects: [] };


### PR DESCRIPTION
## Summary
Refactors the text streaming reduction logic in `sseReducer.ts` to assign the accumulated `streamed` content inline during the message-part updates. 

Previously, the reducer updated the message parts and then resolved the final chunk using an unsafe non-null assertion (`parts[parts.length - 1]!.content`). This change introduces a local `streamed` variable populated directly within both conditional branches (appending to an existing text stream vs. initializing a new stream segment). This improves code safety and eliminates potential runtime indexing errors.

## Related issue
<!-- Use Closes/Fixes/Resolves to link. project-sync moves the linked issue to In Progress. -->
<!-- Closes # -->

## Test plan
- Verify that real-time text streaming over Server-Sent Events (SSE) functions as expected in the widget UI without regressions.
- Ensure the reducer correctly accumulates incremental text chunks.

## Checklist
- [x] CI passes (type-check + lint)
- [ ] Shared contracts in sync if changed (`routes.ts`, `schema.ts`, `proto`)